### PR TITLE
Rework trickle ICE and m=/c= stuff. Fixes #11, #18, #41, #80

### DIFF
--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -1024,9 +1024,9 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
           whether they can actually do Trickle ICE, i.e. safely send an initial
           offer or answer followed later by candidates as they are gathered.
           As "true" is the only value that definitively indicates remote Trickle
-          ICE support, an application which always checks canTrickle will by default
-          attempt Half Trickle on initial offers and Full Trickle on subsequent
-          interactions with a Trickle ICE-compatible agent.
+          ICE support, an application which compares canTrickle against "true" 
+          will by default attempt Half Trickle on initial offers and Full Trickle
+          on subsequent interactions with a Trickle ICE-compatible agent.
           </t>
         </section>
         <section title="setConfiguration" anchor="sec.setconfiguration">


### PR DESCRIPTION
Update of ekr's PR #42. Details:
- Initial offers/answers have no candidates
- Add canTrickle property
- Add text regarding a=end-of-candidates
- Clarify dummy/null address/port stuff
