### PR TITLE
Rework OTRA/OTRV. Fixes #66, #64.

### DIFF
--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -1554,7 +1554,7 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             value of N, and M video MediaStreamTracks have been added to the 
             PeerConnection, the offer MUST include N non-rejected m= sections
             with media type "video", even if N is greater than M.
-            This allows the offerer to receive audio, including multiple independent
+            This allows the offerer to receive video, including multiple independent
             streams, even when not sending it; accordingly, the directional
             attribute on the N-M video m= sections without associated
             MediaStreamTracks MUST be set to recvonly.</t>
@@ -1821,7 +1821,7 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
           description if the following constraints are present.</t>
 
           <section title="VoiceActivityDetection" anchor="sec.voiceactivitydetection2">
-            <t>Handling of the "VoiceActivityDetection" option is answers is the same as is indicated for offers in <xref target="sec.voiceactivitydetection1"></xref>.</t>
+            <t>Handling of the "VoiceActivityDetection" option in answers is the same as is indicated for offers in <xref target="sec.voiceactivitydetection1"></xref>.</t>
           </section>
         </section>
       </section>


### PR DESCRIPTION
ORTA/ORTV can now be set to a number smaller than the number of MSTs,
leading to a=sendonly settings.
Also allowed VAD to work in CreateAnswer. (#64)
