### PR TITLE
Mentioning the end-of-candidates indication in a couple sections.

### DIFF
--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -1243,10 +1243,10 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
           and/or pending remote description according to the rules defined for
           Trickle ICE. Connectivity checks will be sent to the new candidate.</t>
 
-          <t>If this method is called with a null candidate, it provides
-          an end-of-candidates indication (as defined in
-          <xref target="I-D.ietf-ice-trickle"/>) to the ICE Agent for all
-          media descriptions in the last remote description.</t>
+          <t>This method can also be used to provide an end-of-candidates
+          indication (as defined in <xref target="I-D.ietf-ice-trickle"/>)
+          to the ICE Agent for all media descriptions in the last remote
+          description.</t>
 
           <t>This call will result in a change to the state of the ICE Agent,
           and may result in a change to media state if it results in

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -1243,6 +1243,10 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
           and/or pending remote description according to the rules defined for
           Trickle ICE. Connectivity checks will be sent to the new candidate.</t>
 
+          <t>This method can also be used to provide an end-of-candidates
+          indication to the ICE Agent, as defined in
+          <xref target="I-D.ietf-ice-trickle"/>.</t>
+
           <t>This call will result in a change to the state of the ICE Agent,
           and may result in a change to media state if it results in
           connectivity being established.</t>
@@ -2723,6 +2727,9 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             <t>Pair any supplied ICE candidates with any gathered local candidates, as described
             in Section 5.7 of <xref target="RFC5245"/>
             and start connectivity checks with the appropriate credentials.</t>
+            <t>If an "a=end-of-candidates" attribute is present, process the
+            end-of-candidates indication as described in
+            <xref target="I-D.ietf-ice-trickle"/>.</t>
             <t>If the media section proto value indicates use of RTP:
               <list style="symbols">
                 <t>[TODO: header extensions]</t>

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -1243,9 +1243,10 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
           and/or pending remote description according to the rules defined for
           Trickle ICE. Connectivity checks will be sent to the new candidate.</t>
 
-          <t>This method can also be used to provide an end-of-candidates
-          indication to the ICE Agent, as defined in
-          <xref target="I-D.ietf-ice-trickle"/>.</t>
+          <t>If this method is called with a null candidate, it provides
+          an end-of-candidates indication (as defined in
+          <xref target="I-D.ietf-ice-trickle"/>) to the ICE Agent for all
+          media descriptions in the last remote description.</t>
 
           <t>This call will result in a change to the state of the ICE Agent,
           and may result in a change to media state if it results in
@@ -2729,7 +2730,7 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             and start connectivity checks with the appropriate credentials.</t>
             <t>If an "a=end-of-candidates" attribute is present, process the
             end-of-candidates indication as described in
-            <xref target="I-D.ietf-ice-trickle"/>.</t>
+            <xref target="I-D.ietf-ice-trickle"/> Section 11.</t>
             <t>If the media section proto value indicates use of RTP:
               <list style="symbols">
                 <t>[TODO: header extensions]</t>


### PR DESCRIPTION
Specifically, "addIceCandidate" and "Applying a Remote Description".