### PR TITLE
Clarify when an m= section is rejected due to the bundle policy.

### DIFF
--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -1083,7 +1083,10 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
                         streams. This policy balances desire to
                         multiplex with the need to ensure basic audio
                         and video can still be negotiated in legacy
-                        cases.</t>
+                        cases. When acting as answerer, if there is
+                        no bundle group in the offer, the
+                        implementation will reject all but the first
+                        m= section of each type.</t>
 
                         <t></t>
 
@@ -1102,9 +1105,10 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
                         bundle-only. This policy aims to minimize
                         candidate gathering and maximize multiplexing,
                         at the cost of less compatibility with legacy
-                        endpoints. When acting as answerer, the
-                        implementation will reject any m= section that
-                        is not in a bundle group.</t>
+                        endpoints. When acting as answerer, if there
+                        if no bundle group in the offer, the
+                        implementation will reject all but the first
+                        m= section.</t>
 
                     </list></t>
 
@@ -2682,8 +2686,13 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
 
                       <t>No supported codec is present in the offer.</t>
 
-                      <t>The bundle policy is "max-bundle" and the m=
-                      section is not in a bundle group.</t>
+                      <t>The bundle policy is "max-bundle", the m=
+                      section is not in a bundle group, and this is not
+                      the first m= section.</t>
+
+                      <t>The bundle policy is "balanced", the m=
+                      section is not in a bundle group, and this is not
+                      the first m= section for this media type.</t>
 
                       <t>The RTP/RTCP multiplexing policy is "require"
                       and the m= section doesn't contain an


### PR DESCRIPTION
If a non-bundle offer is received, and "max-bundle" is used, the first
m= section should be accepted and all others rejected. This will ensure
the same result whether or not the "max-bundle" endpoint is the offerer
or answerer (ignoring some unlikely corner cases), and will prevent a
lone media description from being rejected if the remote offer didn't
contain a bundle group simply because it wasn't necessary.

Also added equivalent rules for the "balanced" bundle policy.