### PR TITLE
The sess-id field of the o= line can't be 64 bits

### DIFF
--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -1935,7 +1935,7 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
                         field SHOULD be "-". The value of the
                         &lt;sess-id&gt; field SHOULD be a
                         cryptographically random number. To ensure
-                        uniqueness, this number SHOULD be at least 64
+                        uniqueness, this number SHOULD be 63
                         bits long. The value of the &lt;sess-version&gt;
                         field SHOULD be zero. The value of the
                         &lt;nettype&gt; &lt;addrtype&gt;


### PR DESCRIPTION
RFC 3264 says this:

    The numeric value of the session id and version in the o line MUST
    be representable with a 64 bit signed integer.

Since the negative values that can be represented in a 64-bit signed
integer can't be represented by the sess-id grammar (`1*DIGIT`),
the only reasonable conclusion is that this has to be a 63-bit
number.

FWIW, that's what Firefox does, though it will accept 64-bit values
(apparently longer values clamp to ULLONG_MAX).