### PR TITLE
Per Justin's comments, remove all description of generating

### DIFF
--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -1954,30 +1954,6 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
               <xref target="I-D.ietf-rtcweb-rtp-usage"></xref>, Section
               5.1.</t>
 
-              <t>An "a=ssrc" line, as specified in
-              <xref target="RFC5576"></xref>, Section 4.1, indicating
-              the SSRC to be used for sending media, along with the
-              mandatory "cname" source attribute, as specified in
-              Section 6.1, indicating the CNAME for the source. The
-              CNAME MUST be generated in accordance with Section 4.9 of
-
-              <xref target="I-D.ietf-rtcweb-rtp-usage"></xref>.</t>
-
-              <t>If RTX is supported for this media type, another
-              "a=ssrc" line with the RTX SSRC, and an "a=ssrc-group"
-              line, as specified in
-              <xref target="RFC5576"></xref>, section 4.2, with
-              semantics set to "FID" and including the primary and RTX
-              SSRCs.</t>
-
-              <t>If FEC is supported for this media type, another
-              "a=ssrc" line with the FEC SSRC, and an "a=ssrc-group"
-              line with semantics set to "FEC-FR" and including the
-              primary and FEC SSRCs, as specified in
-              <xref target="RFC5956"></xref>, section 4.3. For
-              simplicity, if both RTX and FEC are supported, the FEC
-              SSRC MUST be the same as the RTX SSRC.</t>
-
               <t>If the bundle policy for this PeerConnection is set to
               "max-bundle", and this is not the first m= section, or
               the bundle policy is set to "balanced", and this is not
@@ -1991,30 +1967,6 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
                 <t>An "a=msid" line, as specified in
                 <xref target="I-D.ietf-mmusic-msid"></xref>, Section
                 2.</t>
-
-                <t>An "a=ssrc" line, as specified in
-                <xref target="RFC5576"></xref>, Section 4.1, indicating
-                the SSRC to be used for sending media, along with the
-                mandatory "cname" source attribute, as specified in
-                Section 6.1, indicating the CNAME for the source. The
-                CNAME MUST be generated in accordance with Section 4.9
-                of
-                <xref target="I-D.ietf-rtcweb-rtp-usage"></xref>.</t>
-
-                <t>If RTX is supported for this media type, another
-                "a=ssrc" line with the RTX SSRC, and an "a=ssrc-group"
-                line, as specified in
-                <xref target="RFC5576"></xref>, section 4.2, with
-                semantics set to "FID" and including the primary and
-                RTX SSRCs.</t>
-
-                <t>If FEC is supported for this media type, another
-                "a=ssrc" line with the FEC SSRC, and an "a=ssrc-group"
-                line with semantics set to "FEC-FR" and including the
-                primary and FEC SSRCs, as specified in
-                <xref target="RFC5956"></xref>, section 4.3. For
-                simplicity, if both RTX and FEC are supported, the FEC
-                SSRC MUST be the same as the RTX SSRC.</t>
               </list></t>
 
               <t>If the RtpTransceiver's RtpSender is active, and the
@@ -2212,10 +2164,10 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             with an m= section, and the m= section is not being
             recycled as described above, an m= section MUST be
             generated for it with the port set to zero and the
-            "a=msid", "a=ssrc", and "a=ssrc-group" lines removed.</t>
+            "a=msid" line removed.</t>
 
             <t>For RtpTransceivers that are not stopped, the "a=msid",
-            "a=ssrc", and "a=ssrc-group" lines MUST stay the same if
+            line MUST stay the same if
             they are present in the current description.</t>
 
             <t>Each "m=" and c=" line MUST be filled in with the port,
@@ -2265,8 +2217,7 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             omitted.</t>
 
             <t>For RtpTransceivers that are still present, the
-            "a=msid", "a=ssrc", and "a=ssrc-group" lines MUST stay the
-            same.</t>
+            "a=msid" line MUST stay the same.</t>
 
             <t>For RtpTransceivers that are still present, the "a=rid"
             lines MUST stay the same.</t>
@@ -2275,8 +2226,8 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             "a=simulcast" line MUST stay the same.</t>
 
             <t>If any RtpTransceiver has been stopped, the port MUST be
-            set to zero and the "a=msid", "a=ssrc", and "a=ssrc-group"
-            lines MUST be removed.</t>
+            set to zero and the "a=msid"
+            line MUST be removed.</t>
 
             <t>If any RtpTransceiver has been added, and there exists a
             m= section with a zero port in the current local
@@ -2593,30 +2544,6 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
               <t>An "a=msid" line, as specified in
               <xref target="I-D.ietf-mmusic-msid"></xref>, Section
               2.</t>
-
-              <t>An "a=ssrc" line, as specified in
-              <xref target="RFC5576"></xref>, Section 4.1, indicating
-              the SSRC to be used for sending media, along with the
-              mandatory "cname" source attribute, as specified in
-              Section 6.1, indicating the CNAME for the source. The
-              CNAME MUST be generated in accordance with Section 4.9 of
-
-              <xref target="I-D.ietf-rtcweb-rtp-usage"></xref>.</t>
-
-              <t>If RTX has been negotiated for this m= section,
-              another "a=ssrc" line with the RTX SSRC, and an
-              "a=ssrc-group" line, as specified in
-              <xref target="RFC5576"></xref>, section 4.2, with
-              semantics set to "FID" and including the primary and RTX
-              SSRCs.</t>
-
-              <t>If FEC has been negotiated for this m= section,
-              another "a=ssrc" line with the FEC SSRC, and an
-              "a=ssrc-group" line with semantics set to "FEC-FR" and
-              including the primary and FEC SSRCs, as specified in
-              <xref target="RFC5956"></xref>, section 4.3. For
-              simplicity, if both RTX and FEC are supported, the FEC
-              SSRC MUST be the same as the RTX SSRC.</t>
             </list></t>
           </list></t>
 
@@ -2756,7 +2683,7 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             omitted.</t>
 
             <t>For RtpTransceivers that are not stopped, the "a=msid",
-            "a=ssrc", and "a=ssrc-group" lines MUST stay the same.</t>
+            line MUST stay the same.</t>
           </list></t>
         </section>
         <section title="Options Handling"

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -2166,7 +2166,7 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             generated for it with the port set to zero and the
             "a=msid" line removed.</t>
 
-            <t>For RtpTransceivers that are not stopped, the "a=msid",
+            <t>For RtpTransceivers that are not stopped, the "a=msid"
             line MUST stay the same if
             they are present in the current description.</t>
 
@@ -2682,7 +2682,7 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             "a=candidate" and "a=end-of-candidates" MUST be
             omitted.</t>
 
-            <t>For RtpTransceivers that are not stopped, the "a=msid",
+            <t>For RtpTransceivers that are not stopped, the "a=msid"
             line MUST stay the same.</t>
           </list></t>
         </section>


### PR DESCRIPTION
a=ssrc and a=ssrc-group. Fixes #149.