### PR TITLE
Remove the [TODO rtcp-fb]. All the rtcp-fb attributes are of type

### DIFF
--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -2117,8 +2117,6 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
 
               <t>An "a=rtcp-rsize" line, as specified in
               <xref target="RFC5506"></xref>, Section 5.</t>
-
-              <t>[TODO: rtcp-fb?]</t>
             </list>
           </t>
 


### PR DESCRIPTION
IDENTICAL-PT or SPECIAL which means that they should be in all
the m= sections. Fixes #354.