### PR TITLE
Resolve setDirection TODO

### DIFF
--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -1605,7 +1605,7 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             When creating offers, the transceiver direction is directly
             reflected in the output, even for reoffers. When creating answers,
             the transceiver direction is intersected with the offered direction,
-            as explained in the <xref section="sec.generating-an-answer" />
+            as explained in the <xref target="sec.generating-an-answer" />
             section below.
           </t>
         </section>


### PR DESCRIPTION
Fixes #355.
Also, fixes problem where my previous change to explain the directional
attribute for answers was accidentally applied to the offer section.
