### PR TITLE
Fixing a minor issue in the "rollback" section.

### DIFF
--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -1336,7 +1336,7 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             be set to null. RtpTransceivers that were created by
             applying a remote offer that was subsequently rolled back
             MUST be removed. However, a RtpTransceiver MUST NOT be
-            removed if the RtpTransceiver's RtpSender was activated by
+            removed if a track was attached to the RtpTransceiver via
             the addTrack method. This is so that an application may
             call addTrack, then call setRemoteDescription with an
             offer, then roll back that offer, then call createOffer and


### PR DESCRIPTION
This still refers to RtpSenders being "activated", a concept that isn't
defined anywhere. I replaced this with "track attached to the
transceiver" since that's the terminology that's used elsewhere.
