### PR TITLE
Adding RtpTransceiver currentDirection (and direction) attributes.

### DIFF
--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -1628,9 +1628,9 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             "recvonly", currentDirection returns "sendonly".
           </t>
           <t>
-            If an answer has never been applied containing an m= section
-            associated with the transceiver, or if the transceiver is
-            stopped, currentDirection returns null.
+            If an answer that references this transceiver has not yet been
+            applied, or if the transceiver is stopped, currentDirection
+            returns null.
           </t>
         </section>
         <section title="setCodecPreferences" anchor="sec.transceiver-set-codec-preferences">

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -1609,6 +1609,30 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             section below.
           </t>
         </section>
+        <section title="direction" anchor="sec.transceiver-direction">
+          <t>
+            The direction method returns the last value passed into
+            setDirection. If setDirection has never been called, it
+            returns the direction the transceiver was initialized with.
+          </t>
+        </section>
+        <section title="currentDirection" anchor="sec.transceiver-current-direction">
+          <t>
+            The currentDirection method returns the last negotiated
+            direction for the transceiver's associated m= section. More
+            specifically, it returns the <xref target="RFC3264"></xref>
+            directional attribute of the associated m= section in the last
+            applied answer, with "send" and "recv" directions reversed if
+            it was a remote answer. For example, if the directional
+            attribute for the associated m= section in a remote answer is
+            "recvonly", currentDirection returns "sendonly".
+          </t>
+          <t>
+            If an answer has never been applied containing an m= section
+            associated with the transceiver, or if the transceiver is
+            stopped, currentDirection returns null.
+          </t>
+        </section>
         <section title="setCodecPreferences" anchor="sec.transceiver-set-codec-preferences">
           <t>
             The setCodecPreferences method sets the codec preferences of a


### PR DESCRIPTION
This distinguishes between the direction which was last set via
setDirection (which simply affects offer/answer generation) from the
direction that was negotiated, which affects whether a transceiver can
send/recv media.

Addresses issue #384.