### PR TITLE
Clarifying that re-offers from non-JSEP endpoints can add codecs.

### DIFF
--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -2366,9 +2366,11 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             lines MUST only include codecs present in the most recent
             answer which have not been excluded by the codec preferences
             of the associated transceiver. Note that non-JSEP endpoints
-            are not subject to these restrictions, and MAY offer media
+            are not subject to these restrictions, and might offer media
             formats that were not present in the most recent answer, as
-            specified in <xref target="RFC3264"></xref>, Section 8.</t>
+            specified in <xref target="RFC3264"></xref>, Section 8.
+            Therefore, JSEP endpoints MUST be prepared to receive such
+            offers.</t>
 
             <t>The media formats on the m= line MUST be generated in the
             same order as in the current local description.</t>
@@ -2577,9 +2579,10 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             corresponding order, and MUST exclude any codecs not present
             in the codec preferences or not present in the offer. Note
             that non-JSEP endpoints are not subject to this restriction,
-            and MAY add media formats in the answer that are not present
+            and might add media formats in the answer that are not present
             in the offer, as specified in <xref target="RFC3264"></xref>,
-            Section 6.1.</t>
+            Section 6.1. Therefore, JSEP endpoints MUST be prepared to
+            receive such answers.</t>
 
             <t>Unless excluded by the above restrictions, the media
             formats MUST include the mandatory audio/video codecs as

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -1967,7 +1967,7 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             <t>The media formats in the answer MAY include codecs present
             in the offer that were discarded in a previous offer/answer
             exchange. This is necessary for compatibility with third-
-            party call control and SIP use cases.<t>
+            party call control and SIP use cases.</t>
 
             <t>Unless excluded by the above restrictions, the media
             formats MUST include the mandatory audio/video codecs as

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -1964,6 +1964,11 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             corresponding order, and MUST exclude any codecs not present
             in the codec preferences.</t>
 
+            <t>The media formats in the answer MAY include codecs present
+            in the offer that were discarded in a previous offer/answer
+            exchange. This is necessary for compatibility with third-
+            party call control and SIP use cases.<t>
+
             <t>Unless excluded by the above restrictions, the media
             formats MUST include the mandatory audio/video codecs as
             specified in

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -2365,7 +2365,10 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             <t>The m= line and corresponding "a=rtpmap" and "a=fmtp"
             lines MUST only include codecs present in the most recent
             answer which have not been excluded by the codec preferences
-            of the associated transceiver.</t>
+            of the associated transceiver. Note that non-JSEP endpoints
+            are not subject to these restrictions, and MAY offer media
+            formats that were not present in the most recent answer, as
+            specified in <xref target="RFC3264"></xref>, Section 8.</t>
 
             <t>The media formats on the m= line MUST be generated in the
             same order as in the current local description.</t>
@@ -2572,7 +2575,11 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             <t>If codec preferences have been set for the associated
             transceiver, media formats MUST be generated in the
             corresponding order, and MUST exclude any codecs not present
-            in the codec preferences or not present in the offer.</t>
+            in the codec preferences or not present in the offer. Note
+            that non-JSEP endpoints are not subject to this restriction,
+            and MAY add media formats in the answer that are not present
+            in the offer, as specified in <xref target="RFC3264"></xref>,
+            Section 6.1.</t>
 
             <t>Unless excluded by the above restrictions, the media
             formats MUST include the mandatory audio/video codecs as


### PR DESCRIPTION
Fixes issue #409.