### PR TITLE
Describing RtpSender and RtpReceiver in more detail.

### DIFF
--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -455,7 +455,7 @@ setRemote(ANSWER) |                                   |
         <section title="RtpSenders" anchor="sec.rtpsenders">
 
           <t>RtpSenders allow the application to control how RTP media
-          are sent. An RtpSender is conceptually responsible for the
+          is sent. An RtpSender is conceptually responsible for the
           outgoing RTP stream(s) described by an m= section. This includes
           encoding the attached MediaStreamTrack, sending RTP media
           packets, sending RTCP sender reports, and processing received
@@ -464,7 +464,7 @@ setRemote(ANSWER) |                                   |
         <section title="RtpReceivers" anchor="sec.rtpreceivers">
 
           <t>RtpReceivers allow the application to inspect how RTP media
-          are received. An RtpReceiver is conceptually responsible for the
+          is received. An RtpReceiver is conceptually responsible for the
           incoming RTP stream(s) described by an m= section. This includes
           processing received RTP media packets, decoding the incoming
           stream(s) to produce a remote MediaStreamTrack, processing
@@ -1387,7 +1387,7 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
           <t>If setRemoteDescription was previously called with an
           offer, and setLocalDescription is called with an answer
           (provisional or final), and the media directions are
-          compatible, and media are available to send, this will result
+          compatible, and media is available to send, this will result
           in the starting of media transmission.</t>
         </section>
         <section title="setRemoteDescription"
@@ -1406,7 +1406,7 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
           <t>If setLocalDescription was previously called with an
           offer, and setRemoteDescription is called with an answer
           (provisional or final), and the media directions are
-          compatible, and media are available to send, this will result
+          compatible, and media is available to send, this will result
           in the starting of media transmission.</t>
         </section>
         <section title="currentLocalDescription"

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -455,12 +455,21 @@ setRemote(ANSWER) |                                   |
         <section title="RtpSenders" anchor="sec.rtpsenders">
 
           <t>RtpSenders allow the application to control how RTP media
-          is sent.</t>
+          are sent. An RtpSender is conceptually responsible for the
+          outgoing RTP stream(s) described by an m= section. This includes
+          encoding the attached MediaStreamTrack, sending RTP media
+          packets, sending RTCP sender reports, and processing received
+          RTCP receiver reports.</t>
         </section>
         <section title="RtpReceivers" anchor="sec.rtpreceivers">
 
-          <t>RtpReceivers allows the application to control how RTP
-          media is received.</t>
+          <t>RtpReceivers allow the application to control how RTP media
+          are received. An RtpReceiver is conceptually responsible for the
+          incoming RTP stream(s) described by an m= section. This includes
+          processing received RTP media packets, decoding the incoming
+          stream(s) to produce a remote MediaStreamTrack, processing
+          received RTCP sender reports, and sending RTCP receiver
+          reports.</t>
         </section>
       </section>
       <section title="ICE" anchor="sec.ice">

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -458,8 +458,8 @@ setRemote(ANSWER) |                                   |
           is sent. An RtpSender is conceptually responsible for the
           outgoing RTP stream(s) described by an m= section. This includes
           encoding the attached MediaStreamTrack, sending RTP media
-          packets, sending RTCP sender reports, and processing received
-          RTCP receiver reports.</t>
+          packets, and generating/processing RTCP for the outgoing RTP
+          streams(s).</t>
         </section>
         <section title="RtpReceivers" anchor="sec.rtpreceivers">
 
@@ -467,9 +467,8 @@ setRemote(ANSWER) |                                   |
           is received. An RtpReceiver is conceptually responsible for the
           incoming RTP stream(s) described by an m= section. This includes
           processing received RTP media packets, decoding the incoming
-          stream(s) to produce a remote MediaStreamTrack, processing
-          received RTCP sender reports, and sending RTCP receiver
-          reports.</t>
+          stream(s) to produce a remote MediaStreamTrack, and
+          generating/processing RTCP for the incoming RTP stream(s).</t>
         </section>
       </section>
       <section title="ICE" anchor="sec.ice">

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -463,7 +463,7 @@ setRemote(ANSWER) |                                   |
         </section>
         <section title="RtpReceivers" anchor="sec.rtpreceivers">
 
-          <t>RtpReceivers allow the application to control how RTP media
+          <t>RtpReceivers allow the application to inspect how RTP media
           are received. An RtpReceiver is conceptually responsible for the
           incoming RTP stream(s) described by an m= section. This includes
           processing received RTP media packets, decoding the incoming


### PR DESCRIPTION
Attempts to address issue #377.

Also changed "control" to "inspect" in RtpReceiver description, since an RtpReceiver is readonly and doesn't let an application control anything.