### PR TITLE
Remove MUST language from discussion of ICE policy

### DIFF
--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -579,13 +579,11 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
           server reflexive, and relay. However, in certain cases,
           applications may want to have more specific control over the
           gathering process, due to privacy or related concerns. For
-          example, one may want to suppress the use of host candidates,
-          to avoid exposing information about the local network, or go
-          as far as only using relay candidates, to leak as little
-          location information as possible (note that these choices
-          come with corresponding operational costs). To accomplish
-          this, the browser MUST allow the application to restrict
-          which ICE candidates are used in a session. Note that this
+          example, one may want to only use relay candidates, to leak as little
+          location information as possible (keeping in mind that this choice
+          comes with corresponding operational costs). To accomplish this, the
+          browser allows the application to restrict which ICE candidates
+          are used in a session. Note that this
           filtering is applied on top of any restrictions the browser
           chooses to enforce regarding which IP addresses are permitted
           for the application, as discussed in
@@ -5900,7 +5898,7 @@ a=rtcp-fb:100 nack pli
 
           <t> Clarified rejection of sections that do not have mux-only. </t>
 
-          <t> Add handling of LS groups </t> 
+          <t> Add handling of LS groups </t>
 
         </list>
       </t>

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -581,8 +581,8 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
           gathering process, due to privacy or related concerns. For
           example, one may want to only use relay candidates, to leak as little
           location information as possible (keeping in mind that this choice
-          comes with corresponding operational costs). To accomplish this, the
-          browser allows the application to restrict which ICE candidates
+          comes with corresponding operational costs). To accomplish this,
+          JSEP allows the application to restrict which ICE candidates
           are used in a session. Note that this
           filtering is applied on top of any restrictions the browser
           chooses to enforce regarding which IP addresses are permitted


### PR DESCRIPTION
It’s an API requirement, so the MUST doesn’t belong here.
Fixes #379
Also remove discussion of application filtering of local addresses,
which is no longer believed to be useful.