### PR TITLE
Address Harald's editorial issues. Fixes #426

### DIFF
--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -1970,7 +1970,7 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
 
             <t>To properly indicate use of DTLS, the &lt;proto&gt;
             field MUST be set to "UDP/TLS/RTP/SAVPF", as specified in
-            <xref target="RFC5764" />, Section 8.
+            <xref target="RFC5764" />, Section 8.</t>
 
             <t>If codec preferences have been set for the associated
             transceiver, media formats MUST be generated in the

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -1970,11 +1970,7 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
 
             <t>To properly indicate use of DTLS, the &lt;proto&gt;
             field MUST be set to "UDP/TLS/RTP/SAVPF", as specified in
-            <xref target="RFC5764" />, Section 8, if the default
-            candidate uses UDP transport, or "TCP/DTLS/RTP/SAVPF", as
-            specified in
-            <xref target="RFC7850" /> if
-            the default candidate uses TCP transport.</t>
+            <xref target="RFC5764" />, Section 8.
 
             <t>If codec preferences have been set for the associated
             transceiver, media formats MUST be generated in the
@@ -2161,9 +2157,7 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
           <t>Lastly, if a data channel has been created, a m= section
           MUST be generated for data. The &lt;media&gt; field MUST be
           set to "application" and the &lt;proto&gt; field MUST be set
-          to "UDP/DTLS/SCTP" if the default candidate uses UDP
-          transport, or "TCP/DTLS/SCTP" if the default candidate uses
-          TCP transport
+          to "UDP/DTLS/SCTP"
           <xref target="I-D.ietf-mmusic-sctp-sdp"></xref>. The "fmt"
           value MUST be set to "webrtc-datachannel" as specified in
           <xref target="I-D.ietf-mmusic-sctp-sdp"></xref>, Section
@@ -2247,7 +2241,8 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             generated &lt;session-version&gt; is independent of the
             &lt;session-version&gt; of the current local description;
             in particular, in the case where the current version is N,
-            an offer is created with version N+1, and then that offer
+            an offer is created with version N+1, then installed with
+            setLocalDescription, and then that offer
             is rolled back so that the current version is again N, the
             next generated offer will still have version N+2.</t>
           </list></t>
@@ -2359,7 +2354,7 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             added RtpTransceiver as if the m= section were being added
             to session description, except that instead of adding it,
             the generated m= section replaces the m= section with a
-            zero port.</t>
+            zero port. The new m= section MUST contain a new MID.</t>
           </list></t>
 
           <t>If the initial offer was applied using
@@ -2374,7 +2369,7 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
           <t>In addition, for each non-recycled, non-rejected m=
           section in the new offer, the following adjustments are made
           based on the contents of the corresponding m= section in the
-          current remote description:
+          current remote description (if any):
           <list style="symbols">
 
             <t>The m= line and corresponding "a=rtpmap" and "a=fmtp"


### PR DESCRIPTION
cf. #426 

> Section 5.2.1 "an m= section being recycled" - first use of term
> "recycled". Link?
> 
> Section 5.2.1 CreateOffer "given that no candidates have yet been
> gathered" - when people remember the pre-gathered candidate pool, this
> can be confusing. Suggest adding a note at the top of this section
> saying that CreateOffer doesn't cause candidate gathering and does not
> take candidates from the pre-gathered pool, and thus, no candidates are
> available at the initial call to CreateOffer. All subsequent references
> to "no candidates have yet been gathered" in this section should be
> replaced with "no candidates are available".

We handled this differently.


> Section 5.2.1 bullet 2 (first list) references use of the default
> candidate (which doesn't exist here). Suggest saying "UDP/TLS/RTP/SAVPF"
> and moving the default candidate language to subsequent offers.

I'm actually going to go further and suggest that we just use UDP
all the time. This whole UDP/TCP thing is a curse.


> Section 5.2.1 CreateOffer - bullet on imageattr - limits on images
> that can be decoded - suggest adding text that this is also included on
> recvonly lines because direction of lines can change.

I don't understand why this text is necessary...of course you want
it for recvonly/sendrecv. Do you mean sendonly?


> Section 5.2.1 "The following attributes ... MUST appear only in "m="
> sections which either have a unique address or which are associated with
> the bundle-tag". This is different from BUNDLE 8.1 - they should either
> say the same thing or have a clear explanation of the difference.

Do you believe that there is a conflict or just that we are prescribing
something that bundle leaves open.


> Section 5.2.1 "a=fingerprint" - needs rewriting for the
> multiple-fingerprint-algorithm case (4572bis). Issue already filed?

This appears to be right now.


> Section 5.2.2 Subsequent offers - is there any reason to allow NOT
> incrementing the session-version?

We discussed this extensively and decided that this was the best
approach.


> Section 5.2.2 The example of rollback doesn't make sense - it works if
> "an offer is created with version N+1" is replaced with "an offer is
> created with version N+1 and installed with SetLocalDescription"

Done.


> Section 5.2.2 recycling of zero-port m-lines - should it specify that
> the new m= section MUST have a different mid than the replaced m= section?

Done.


> Section 5.2.2 "the following adjustments are made based on the content
> of the corresponding m= section in the current remote description" -
> needs to be contained by "if there is a current remote description".

done.
