### PR TITLE
Use a real-world minimum decoder size

### DIFF
--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -721,15 +721,16 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
           differing capabilities, specific "a=imageattr" attributes
           MUST be inserted for each payload type.</t>
 
-          <t>As an example, consider a system with a HD-capable,
-          multiformat video decoder, where the application has
+          <t>As an example, consider a system with a multiformat video decoder,
+          which is capable of decoding any resolution from 48x48 to 720p,
+          and where the application has
           constrained the received track to at most 360p. In this case,
           the implementation would generate this attribute:</t>
 
-          <t>a=imageattr:* recv [x=[16:640],y=[16:360],q=1.0]</t>
+          <t>a=imageattr:* recv [x=[48:640],y=[48:360],q=1.0]</t>
 
           <t>This declaration indicates that the receiver is capable of
-          decoding any image resolution from 16x16 up to 640x360
+          decoding any image resolution from 48x48 up to 640x360
           pixels.</t>
         </section>
         <section title="Interpreting an imageattr Attribute">


### PR DESCRIPTION
This is from the Windows HW offload framework, and spells things out more specifically in the surrounding text.
Fixes #416