### PR TITLE
Move text about matching DTLS role to "subsequent answer" section.

### DIFF
--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -2705,9 +2705,7 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
               for use in DTLS-SRTP scenarios in
               <xref target="RFC5763"></xref>, Section 5. The role value
               in the answer MUST be "active" or "passive"; the "active"
-              role is RECOMMENDED. The role value MUST be consistent
-              with the existing DTLS connection, if one exists and is
-              being continued.</t>
+              role is RECOMMENDED.</t>
 
               <t>An "a=dtls-id" line, as specified in
               <xref target="I-D.ietf-mmusic-dtls-sdp"/> Section 5.3.</t>
@@ -2804,6 +2802,10 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             <xref target="RFC5245"></xref>, Section 9.2.1.1. If the m=
             section is bundled into another m= section, it still MUST
             NOT contain any ICE credentials.</t>
+
+            <t>Each "a=setup" line MUST use an "active" or "passive" role
+            value consistent with the existing DTLS association, if the
+            association is being continued by the offerer.</t>
 
             <t>If the m= section is not bundled into another m=
             section and RTCP multiplexing is not active, an "a=rtcp" attribute


### PR DESCRIPTION
Related to issue #448