### PR TITLE
Machine-generate examples

### DIFF
--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -3901,14 +3901,12 @@ v=0
 o=- 4962303333179871722 1 IN IP4 0.0.0.0
 s=-
 t=0 0
-a=group:BUNDLE a1 v1
 a=ice-options:trickle
+a=group:BUNDLE a1 v1
 m=audio 56500 UDP/TLS/RTP/SAVPF 96 0 8 97 98
 c=IN IP4 192.0.2.1
 a=mid:a1
-a=rtcp:56501 IN IP4 192.0.2.1
 a=msid:47017fee-b6c1-4162-929c-a25110252400
-       f83006c5-a0ff-4e0a-9ed9-d3e6747be7d9
 a=sendrecv
 a=rtpmap:96 opus/48000/2
 a=rtpmap:0 PCMU/8000
@@ -3916,48 +3914,46 @@ a=rtpmap:8 PCMA/8000
 a=rtpmap:97 telephone-event/8000
 a=rtpmap:98 telephone-event/48000
 a=maxptime:120
-a=ice-ufrag:ETEn1v9DoTMB9J4r
-a=ice-pwd:OtSK0WpNtpUjkY4+86js7ZQl
-a=fingerprint:sha-256
-              19:E2:1C:3B:4B:9F:81:E6:B8:5C:F4:A5:A8:D8:73:04
-             :BB:05:2F:70:9F:04:A9:0E:05:E9:26:33:E8:70:88:A2
-a=setup:actpass
-a=rtcp-mux
-a=rtcp-rsize
 a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
 a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
-a=candidate:3348148302 1 udp 2113937151 192.0.2.1 56500
-            typ host
-a=candidate:3348148302 2 udp 2113937151 192.0.2.1 56501
-            typ host
+a=ice-ufrag:ETEn
+a=ice-pwd:OtSK0WpNtpUjkY4+86js7ZQl
+a=fingerprint:sha-256
+              19:E2:1C:3B:4B:9F:81:E6:B8:5C:F4:A5:A8:D8:73:04:
+              BB:05:2F:70:9F:04:A9:0E:05:E9:26:33:E8:70:88:A2
+a=setup:actpass
+a=dtls-id:1
+a=rtcp:56501 IN IP4 192.0.2.1
+a=rtcp-mux
+a=rtcp-rsize
+a=candidate:1 1 udp 2113929471 192.0.2.1 56500 typ host
+a=candidate:1 2 udp 2113929470 192.0.2.1 56501 typ host
 a=end-of-candidates
 
 m=video 56502 UDP/TLS/RTP/SAVPF 100 101
 c=IN IP4 192.0.2.1
-a=rtcp:56503 IN IP4 192.0.2.1
 a=mid:v1
 a=msid:61317484-2ed4-49d7-9eb7-1414322a7aae
-       f30bdb4a-5db8-49b5-bcdc-e0c9a23172e0
 a=sendrecv
 a=rtpmap:100 VP8/90000
 a=rtpmap:101 rtx/90000
 a=fmtp:101 apt=100
-a=ice-ufrag:BGKkWnG5GmiUpdIV
-a=ice-pwd:mqyWsAjvtKwTGnvhPztQ9mIf
-a=fingerprint:sha-256
-              19:E2:1C:3B:4B:9F:81:E6:B8:5C:F4:A5:A8:D8:73:04
-             :BB:05:2F:70:9F:04:A9:0E:05:E9:26:33:E8:70:88:A2
-a=setup:actpass
-a=rtcp-mux
-a=rtcp-rsize
 a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:mid
 a=rtcp-fb:100 ccm fir
 a=rtcp-fb:100 nack
 a=rtcp-fb:100 nack pli
-a=candidate:3348148302 1 udp 2113937151 192.0.2.1 56502
-            typ host
-a=candidate:3348148302 2 udp 2113937151 192.0.2.1 56503
-            typ host
+a=ice-ufrag:BGKk
+a=ice-pwd:mqyWsAjvtKwTGnvhPztQ9mIf
+a=fingerprint:sha-256
+              19:E2:1C:3B:4B:9F:81:E6:B8:5C:F4:A5:A8:D8:73:04:
+              BB:05:2F:70:9F:04:A9:0E:05:E9:26:33:E8:70:88:A2
+a=setup:actpass
+a=dtls-id:1
+a=rtcp:56503 IN IP4 192.0.2.1
+a=rtcp-mux
+a=rtcp-rsize
+a=candidate:1 1 udp 2113929471 192.0.2.1 56502 typ host
+a=candidate:1 2 udp 2113929470 192.0.2.1 56503 typ host
 a=end-of-candidates
           ]]>
 </artwork>
@@ -3974,13 +3970,12 @@ v=0
 o=- 6729291447651054566 1 IN IP4 0.0.0.0
 s=-
 t=0 0
+a=ice-options:trickle
 a=group:BUNDLE a1 v1
-m=audio 20000 UDP/TLS/RTP/SAVPF 96 0 8 97 98
+m=audio 34300 UDP/TLS/RTP/SAVPF 96 0 8 97 98
 c=IN IP4 192.0.2.2
 a=mid:a1
-a=rtcp:20000 IN IP4 192.0.2.2
-a=msid:PI39StLS8W7ZbQl1sJsWUXkr3Zf12fJUvzQ1
-       PI39StLS8W7ZbQl1sJsWUXkr3Zf12fJUvzQ1a0
+a=msid:5a7b57b8-f043-4bd1-a45d-09d4dfa31226
 a=sendrecv
 a=rtpmap:96 opus/48000/2
 a=rtpmap:0 PCMU/8000
@@ -3988,33 +3983,29 @@ a=rtpmap:8 PCMA/8000
 a=rtpmap:97 telephone-event/8000
 a=rtpmap:98 telephone-event/48000
 a=maxptime:120
-a=ice-ufrag:6sFvz2gdLkEwjZEr
+a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
+a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
+a=ice-ufrag:6sFv
 a=ice-pwd:cOTZKZNVlO9RSGsEGM63JXT2
-a=fingerprint:sha-256 6B:8B:F0:65:5F:78:E2:51:3B:AC:6F:F3:3F:46:1B:35
-            :DC:B8:5F:64:1A:24:C2:43:F0:A1:58:D0:A1:2C:19:08
+a=fingerprint:sha-256
+              6B:8B:F0:65:5F:78:E2:51:3B:AC:6F:F3:3F:46:1B:35:
+              DC:B8:5F:64:1A:24:C2:43:F0:A1:58:D0:A1:2C:19:08
 a=setup:active
+a=dtls-id:1
 a=rtcp-mux
 a=rtcp-rsize
-a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
-a=candidate:2299743422 1 udp 2113937151 192.0.2.2 20000
-            typ host
+a=candidate:1 1 udp 2113929471 192.0.2.2 34300 typ host
 a=end-of-candidates
 
-m=video 20000 UDP/TLS/RTP/SAVPF 100 101
+m=video 34300 UDP/TLS/RTP/SAVPF 100 101
 c=IN IP4 192.0.2.2
-a=rtcp 20001 IN IP4 192.0.2.2
 a=mid:v1
-a=msid:PI39StLS8W7ZbQl1sJsWUXkr3Zf12fJUvzQ1
-       PI39StLS8W7ZbQl1sJsWUXkr3Zf12fJUvzQ1v0
+a=msid:4ea4d4a1-2fda-4511-a9cc-1b32c2e59552
 a=sendrecv
 a=rtpmap:100 VP8/90000
 a=rtpmap:101 rtx/90000
 a=fmtp:101 apt=100
-a=fingerprint:sha-256 6B:8B:F0:65:5F:78:E2:51:3B:AC:6F:F3:3F:46:1B:35
-                     :DC:B8:5F:64:1A:24:C2:43:F0:A1:58:D0:A1:2C:19:08
-a=setup:active
-a=rtcp-mux
-a=rtcp-rsize
+a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:mid
 a=rtcp-fb:100 ccm fir
 a=rtcp-fb:100 nack
 a=rtcp-fb:100 nack pli

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -3903,10 +3903,10 @@ s=-
 t=0 0
 a=ice-options:trickle
 a=group:BUNDLE a1 v1
+
 m=audio 56500 UDP/TLS/RTP/SAVPF 96 0 8 97 98
 c=IN IP4 192.0.2.1
 a=mid:a1
-a=msid:47017fee-b6c1-4162-929c-a25110252400
 a=sendrecv
 a=rtpmap:96 opus/48000/2
 a=rtpmap:0 PCMU/8000
@@ -3916,6 +3916,8 @@ a=rtpmap:98 telephone-event/48000
 a=maxptime:120
 a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
 a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
+a=msid:47017fee-b6c1-4162-929c-a25110252400
+       f83006c5-a0ff-4e0a-9ed9-d3e6747be7d9
 a=ice-ufrag:ETEn
 a=ice-pwd:OtSK0WpNtpUjkY4+86js7ZQl
 a=fingerprint:sha-256
@@ -3933,7 +3935,6 @@ a=end-of-candidates
 m=video 56502 UDP/TLS/RTP/SAVPF 100 101
 c=IN IP4 192.0.2.1
 a=mid:v1
-a=msid:61317484-2ed4-49d7-9eb7-1414322a7aae
 a=sendrecv
 a=rtpmap:100 VP8/90000
 a=rtpmap:101 rtx/90000
@@ -3942,6 +3943,8 @@ a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:mid
 a=rtcp-fb:100 ccm fir
 a=rtcp-fb:100 nack
 a=rtcp-fb:100 nack pli
+a=msid:47017fee-b6c1-4162-929c-a25110252400
+       f30bdb4a-5db8-49b5-bcdc-e0c9a23172e0
 a=ice-ufrag:BGKk
 a=ice-pwd:mqyWsAjvtKwTGnvhPztQ9mIf
 a=fingerprint:sha-256
@@ -3956,7 +3959,7 @@ a=candidate:1 1 udp 2113929471 192.0.2.1 56502 typ host
 a=candidate:1 2 udp 2113929470 192.0.2.1 56503 typ host
 a=end-of-candidates
           ]]>
-</artwork>
+            </artwork>
           </figure>
         </t>
 
@@ -3972,10 +3975,10 @@ s=-
 t=0 0
 a=ice-options:trickle
 a=group:BUNDLE a1 v1
+
 m=audio 34300 UDP/TLS/RTP/SAVPF 96 0 8 97 98
 c=IN IP4 192.0.2.2
 a=mid:a1
-a=msid:5a7b57b8-f043-4bd1-a45d-09d4dfa31226
 a=sendrecv
 a=rtpmap:96 opus/48000/2
 a=rtpmap:0 PCMU/8000
@@ -3985,6 +3988,8 @@ a=rtpmap:98 telephone-event/48000
 a=maxptime:120
 a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
 a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
+a=msid:61317484-2ed4-49d7-9eb7-1414322a7aae
+       5a7b57b8-f043-4bd1-a45d-09d4dfa31226
 a=ice-ufrag:6sFv
 a=ice-pwd:cOTZKZNVlO9RSGsEGM63JXT2
 a=fingerprint:sha-256
@@ -4000,7 +4005,6 @@ a=end-of-candidates
 m=video 34300 UDP/TLS/RTP/SAVPF 100 101
 c=IN IP4 192.0.2.2
 a=mid:v1
-a=msid:4ea4d4a1-2fda-4511-a9cc-1b32c2e59552
 a=sendrecv
 a=rtpmap:100 VP8/90000
 a=rtpmap:101 rtx/90000
@@ -4009,8 +4013,10 @@ a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:mid
 a=rtcp-fb:100 ccm fir
 a=rtcp-fb:100 nack
 a=rtcp-fb:100 nack pli
+a=msid:61317484-2ed4-49d7-9eb7-1414322a7aae
+       4ea4d4a1-2fda-4511-a9cc-1b32c2e59552
           ]]>
-</artwork>
+            </artwork>
           </figure>
         </t>
       </section>

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -3914,8 +3914,8 @@ a=rtpmap:8 PCMA/8000
 a=rtpmap:97 telephone-event/8000
 a=rtpmap:98 telephone-event/48000
 a=maxptime:120
-a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
-a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
+a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid
+a=extmap:2 urn:ietf:params:rtp-hdrext:ssrc-audio-level
 a=msid:47017fee-b6c1-4162-929c-a25110252400
        f83006c5-a0ff-4e0a-9ed9-d3e6747be7d9
 a=ice-ufrag:ETEn
@@ -3939,7 +3939,7 @@ a=sendrecv
 a=rtpmap:100 VP8/90000
 a=rtpmap:101 rtx/90000
 a=fmtp:101 apt=100
-a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:mid
+a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid
 a=rtcp-fb:100 ccm fir
 a=rtcp-fb:100 nack
 a=rtcp-fb:100 nack pli
@@ -3986,8 +3986,8 @@ a=rtpmap:8 PCMA/8000
 a=rtpmap:97 telephone-event/8000
 a=rtpmap:98 telephone-event/48000
 a=maxptime:120
-a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
-a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
+a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid
+a=extmap:2 urn:ietf:params:rtp-hdrext:ssrc-audio-level
 a=msid:61317484-2ed4-49d7-9eb7-1414322a7aae
        5a7b57b8-f043-4bd1-a45d-09d4dfa31226
 a=ice-ufrag:6sFv
@@ -4009,7 +4009,7 @@ a=sendrecv
 a=rtpmap:100 VP8/90000
 a=rtpmap:101 rtx/90000
 a=fmtp:101 apt=100
-a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:mid
+a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid
 a=rtcp-fb:100 ccm fir
 a=rtcp-fb:100 nack
 a=rtcp-fb:100 nack pli
@@ -4158,8 +4158,8 @@ a=fingerprint:sha-256
 a=setup:actpass
 a=rtcp-mux
 a=rtcp-rsize
-a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
 a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
+a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
 
 m=application 0 UDP/DTLS/SCTP webrtc-datachannel
 c=IN IP4 0.0.0.0

--- a/gen_examples.py
+++ b/gen_examples.py
@@ -1,397 +1,243 @@
-offer_a1 = """
-  v=0
-  o=- 4962303333179871722 1 IN IP4 0.0.0.0
-  s=-
-  t=0 0
-  a=group:BUNDLE a1 v1
-  a=ice-options:trickle
-  m=audio 56500 UDP/TLS/RTP/SAVPF 96 0 8 97 98
-  c=IN IP4 192.0.2.1
-  a=mid:a1
-  a=rtcp:56501 IN IP4 192.0.2.1
-  a=msid:47017fee-b6c1-4162-929c-a25110252400
-         f83006c5-a0ff-4e0a-9ed9-d3e6747be7d9
-  a=sendrecv
-  a=rtpmap:96 opus/48000/2
-  a=rtpmap:0 PCMU/8000
-  a=rtpmap:8 PCMA/8000
-  a=rtpmap:97 telephone-event/8000
-  a=rtpmap:98 telephone-event/48000
-  a=maxptime:120
-  a=ice-ufrag:ETEn1v9DoTMB9J4r
-  a=ice-pwd:OtSK0WpNtpUjkY4+86js7ZQl
-  a=fingerprint:sha-256
-                19:E2:1C:3B:4B:9F:81:E6:B8:5C:F4:A5:A8:D8:73:04
-               :BB:05:2F:70:9F:04:A9:0E:05:E9:26:33:E8:70:88:A2
-  a=setup:actpass
-  a=rtcp-mux
-  a=rtcp-rsize
-  a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
-  a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
-  a=candidate:3348148302 1 udp 2113937151 192.0.2.1 56500
-              typ host
-  a=candidate:3348148302 2 udp 2113937151 192.0.2.1 56501
-              typ host
-  a=end-of-candidates
 
-  m=video 56502 UDP/TLS/RTP/SAVPF 100 101
-  c=IN IP4 192.0.2.1
-  a=rtcp:56503 IN IP4 192.0.2.1
-  a=mid:v1
-  a=msid:61317484-2ed4-49d7-9eb7-1414322a7aae
-         f30bdb4a-5db8-49b5-bcdc-e0c9a23172e0
-  a=sendrecv
-  a=rtpmap:100 VP8/90000
-  a=rtpmap:101 rtx/90000
-  a=fmtp:101 apt=100
-  a=ice-ufrag:BGKkWnG5GmiUpdIV
-  a=ice-pwd:mqyWsAjvtKwTGnvhPztQ9mIf
-  a=fingerprint:sha-256
-                19:E2:1C:3B:4B:9F:81:E6:B8:5C:F4:A5:A8:D8:73:04
-               :BB:05:2F:70:9F:04:A9:0E:05:E9:26:33:E8:70:88:A2
-  a=setup:actpass
-  a=rtcp-mux
-  a=rtcp-rsize
-  a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:mid
-  a=rtcp-fb:100 ccm fir
-  a=rtcp-fb:100 nack
-  a=rtcp-fb:100 nack pli
-  a=candidate:3348148302 1 udp 2113937151 192.0.2.1 56502
-              typ host
-  a=candidate:3348148302 2 udp 2113937151 192.0.2.1 56503
-              typ host
-  a=end-of-candidates
-"""
+class PeerConnection:
+  SESSION_SDP = \
+ """v=0
+    o=- {0.session_id} {0.version} IN IP4 0.0.0.0
+    s=-
+    t=0 0
+    a=ice-options:trickle
+    a=group:BUNDLE a1 v1
+    """
+# TODO: allow configurable BUNDLE
 
-answer_a1 =
-"""
-  v=0
-  o=- 6729291447651054566 1 IN IP4 0.0.0.0
-  s=-
-  t=0 0
-  a=group:BUNDLE a1 v1
-  m=audio 20000 UDP/TLS/RTP/SAVPF 96 0 8 97 98
-  c=IN IP4 192.0.2.2
-  a=mid:a1
-  a=rtcp:20000 IN IP4 192.0.2.2
-  a=msid:PI39StLS8W7ZbQl1sJsWUXkr3Zf12fJUvzQ1
-         PI39StLS8W7ZbQl1sJsWUXkr3Zf12fJUvzQ1a0
-  a=sendrecv
-  a=rtpmap:96 opus/48000/2
-  a=rtpmap:0 PCMU/8000
-  a=rtpmap:8 PCMA/8000
-  a=rtpmap:97 telephone-event/8000
-  a=rtpmap:98 telephone-event/48000
-  a=maxptime:120
-  a=ice-ufrag:6sFvz2gdLkEwjZEr
-  a=ice-pwd:cOTZKZNVlO9RSGsEGM63JXT2
-  a=fingerprint:sha-256 6B:8B:F0:65:5F:78:E2:51:3B:AC:6F:F3:3F:46:1B:35
-              :DC:B8:5F:64:1A:24:C2:43:F0:A1:58:D0:A1:2C:19:08
-  a=setup:active
-  a=rtcp-mux
-  a=rtcp-rsize
-  a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
-  a=candidate:2299743422 1 udp 2113937151 192.0.2.2 20000
-              typ host
-  a=end-of-candidates
+  TRANSPORT_SDP_PRE_RTCP = \
+ """a=ice-ufrag:{0[ice_ufrag]}
+    a=ice-pwd:{0[ice_pwd]}
+    a=fingerprint:sha-256 {0[dtls_fingerprint]}
+    a=setup:{0[dtls_dir]}
+    a=dtls-id:1
+    """
+  TRANSPORT_SDP_RTCP = \
+ """a=rtcp:{0[local_rtcp]} IN IP4 {0[local_ip]}
+    """
+  TRANSPORT_SDP_POST_RTCP = \
+ """a=rtcp-mux
+    a=rtcp-rsize
+    """
+  TRANSPORT_SDP_WITH_RTCP = TRANSPORT_SDP_PRE_RTCP + TRANSPORT_SDP_RTCP + \
+                            TRANSPORT_SDP_POST_RTCP
+  TRANSPORT_SDP_NO_RTCP = TRANSPORT_SDP_PRE_RTCP + TRANSPORT_SDP_POST_RTCP
+# TODO: rtcp-mux-only
 
-  m=video 20000 UDP/TLS/RTP/SAVPF 100 101
-  c=IN IP4 192.0.2.2
-  a=rtcp 20001 IN IP4 192.0.2.2
-  a=mid:v1
-  a=msid:PI39StLS8W7ZbQl1sJsWUXkr3Zf12fJUvzQ1
-         PI39StLS8W7ZbQl1sJsWUXkr3Zf12fJUvzQ1v0
-  a=sendrecv
-  a=rtpmap:100 VP8/90000
-  a=rtpmap:101 rtx/90000
-  a=fmtp:101 apt=100
-  a=fingerprint:sha-256 6B:8B:F0:65:5F:78:E2:51:3B:AC:6F:F3:3F:46:1B:35
-                       :DC:B8:5F:64:1A:24:C2:43:F0:A1:58:D0:A1:2C:19:08
-  a=setup:active
-  a=rtcp-mux
-  a=rtcp-rsize
-  a=rtcp-fb:100 ccm fir
-  a=rtcp-fb:100 nack
-  a=rtcp-fb:100 nack pli
-"""
+  AUDIO_SDP = \
+ """m=audio {0[local_port]} UDP/TLS/RTP/SAVPF 96 0 8 97 98
+    c=IN IP4 {0[local_ip]}
+    a=mid:{0[mid]}
+    a=msid:{0[msid]}
+    a=sendrecv
+    a=rtpmap:96 opus/48000/2
+    a=rtpmap:0 PCMU/8000
+    a=rtpmap:8 PCMA/8000
+    a=rtpmap:97 telephone-event/8000
+    a=rtpmap:98 telephone-event/48000
+    a=maxptime:120
+    a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
+    a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
+    """
+  # TODO: proper default candidate in c=, m=, rtcp lines
 
-offer_b1 = """
-  v=0
-  o=- 4962303333179871723 1 IN IP4 0.0.0.0
-  s=-
-  t=0 0
-  a=group:BUNDLE a1 d1
-  a=ice-options:trickle
-  m=audio 9 UDP/TLS/RTP/SAVPF 96 0 8 97 98
-  c=IN IP4 0.0.0.0
-  a=rtcp:9 IN IP4 0.0.0.0
-  a=mid:a1
-  a=msid:57017fee-b6c1-4162-929c-a25110252400
-         e83006c5-a0ff-4e0a-9ed9-d3e6747be7d9
-  a=sendrecv
-  a=rtpmap:96 opus/48000/2
-  a=rtpmap:0 PCMU/8000
-  a=rtpmap:8 PCMA/8000
-  a=rtpmap:97 telephone-event/8000
-  a=rtpmap:98 telephone-event/48000
-  a=maxptime:120
-  a=ice-ufrag:ATEn1v9DoTMB9J4r
-  a=ice-pwd:AtSK0WpNtpUjkY4+86js7ZQl
-  a=fingerprint:sha-256
-                19:E2:1C:3B:4B:9F:81:E6:B8:5C:F4:A5:A8:D8:73:04
-               :BB:05:2F:70:9F:04:A9:0E:05:E9:26:33:E8:70:88:A2
-  a=setup:actpass
-  a=rtcp-mux
-  a=rtcp-rsize
-  a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
-  a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
+  VIDEO_SDP = \
+ """m=video {0[local_port]} UDP/TLS/RTP/SAVPF 100 101
+    c=IN IP4 {0[local_ip]}
+    a=mid:{0[mid]}
+    a=msid:{0[msid]}
+    a=sendrecv
+    a=rtpmap:100 VP8/90000
+    a=rtpmap:101 rtx/90000
+    a=fmtp:101 apt=100
+    a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:mid
+    a=rtcp-fb:100 ccm fir
+    a=rtcp-fb:100 nack
+    a=rtcp-fb:100 nack pli
+    """
 
-  m=application 0 UDP/DTLS/SCTP webrtc-datachannel
-  c=IN IP4 0.0.0.0
-  a=bundle-only
-  a=mid:d1
-  a=fmtp:webrtc-datachannel max-message-size=65536
-  a=sctp-port 5000
-  a=fingerprint:sha-256 19:E2:1C:3B:4B:9F:81:E6:B8:5C:F4:A5:A8:D8:73:04
-                       :BB:05:2F:70:9F:04:A9:0E:05:E9:26:33:E8:70:88:A2
-  a=setup:actpass
-"""
+  DATA_SDP = \
+ """m=application {0[local_port]} UDP/DTLS/SCTP webrtc-datachannel
+    c=IN IP4 {0[local_ip]}
+    a=mid:{0[mid]}
+    a=fmtp:webrtc-datachannel max-message-size=65536
+    a=sctp-port 5000
+    """
 
-candidate_b1 = """
-  candidate:109270923 1 udp 2122194687 192.168.1.2 51556 typ host
-"""
+  CANDIDATE_ATTR = 'candidate:{0} {1} {2} {3} {4} {5} typ {6}'
+  CANDIDATE_ATTR_WITH_RADDR = CANDIDATE_ATTR + ' raddr {7} rport {8}'
 
-candidate_b2 = """
-  candidate:4036177503 1 udp 1685987071 11.22.33.44 52546 typ srflx
-            raddr 192.168.1.2 rport 51556
-"""
+  END_OF_CANDIDATES_SDP = \
+ """a=end-of-candidates
+    """
 
-answer_b1 = """
-o=- 7729291447651054566 1 IN IP4 0.0.0.0
-s=-
-t=0 0
-a=group:BUNDLE a1 d1
-a=ice-options:trickle
-m=audio 9 UDP/TLS/RTP/SAVPF 96 0 8 97 98
-c=IN IP4 0.0.0.0
-a=rtcp:9 IN IP4 0.0.0.0
-a=mid:a1
-a=msid:QI39StLS8W7ZbQl1sJsWUXkr3Zf12fJUvzQ1
-       QI39StLS8W7ZbQl1sJsWUXkr3Zf12fJUvzQ1a0
-a=sendrecv
-a=rtpmap:96 opus/48000/2
-a=rtpmap:0 PCMU/8000
-a=rtpmap:8 PCMA/8000
-a=rtpmap:97 telephone-event/8000
-a=rtpmap:98 telephone-event/48000
-a=maxptime:120
-a=ice-ufrag:7sFvz2gdLkEwjZEr
-a=ice-pwd:dOTZKZNVlO9RSGsEGM63JXT2
-a=fingerprint:sha-256 6B:8B:F0:65:5F:78:E2:51:3B:AC:6F:F3:3F:46:1B:35
-                     :DC:B8:5F:64:1A:24:C2:43:F0:A1:58:D0:A1:2C:19:08
-a=setup:active
-a=rtcp-mux
-a=rtcp-rsize
-a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
-a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
+  def __init__(self, session_id, trickle, bundle_policy, mux_policy,
+               local_ip, stun_ip, relay_ip, fingerprint, m_sections):
+    self.session_id = session_id
+    self.trickle = trickle
+    self.bundle_policy = bundle_policy
+    self.mux_policy = mux_policy
+    self.local_ip = local_ip
+    self.stun_ip = stun_ip
+    self.relay_ip = relay_ip
+    self.fingerprint = fingerprint
+    self.m_sections = m_sections
+    self.version = 0
 
-m=application 9 UDP/DTLS/SCTP webrtc-datachannel
-c=IN IP4 0.0.0.0
-a=mid:d1
-a=fmtp:webrtc-datachannel max-message-size=65536
-a=sctp-port 5000
-a=fingerprint:sha-256 6B:8B:F0:65:5F:78:E2:51:3B:AC:6F:F3:3F:46:1B:35
-                     :DC:B8:5F:64:1A:24:C2:43:F0:A1:58:D0:A1:2C:19:08
-a=setup:active
+  def create_candidate(self, component, type, addr, port, raddr, rport):
+    if type == 'host':
+      formatter = self.CANDIDATE_ATTR
+      type_priority = 126
+    elif type == 'srflx':
+      formatter = self.CANDIDATE_ATTR_WITH_RADDR
+      type_priority = 110
+    else:
+      formatter = self.CANDIDATE_ATTR_WITH_RADDR
+      type_priority = 0
+    foundation = 1
+    protocol = 'udp'
+    priority = type_priority << 24 | (256 - component)
+    return 'a=' + formatter.format(foundation, component, protocol, priority,
+                                   addr, port, type, raddr, rport) + '\n'
 
-// candidate B3
+  def create_candidates(self, m_section, components):
+    sdp = ''
+    for i in range(0, components):
+      sdp += self.create_candidate(i + 1, 'host',
+                                   self.local_ip, m_section['local_port'] + i,
+                                   None, None)
+    if self.stun_ip:
+      for i in range(0, components):
+        sdp += self.create_candidate(i + 1, 'srflx',
+                                     self.stun_ip, m_section['srflx_port'] + i,
+                                     self.local_ip, m_section['local_port'] + i)
+    if self.relay_ip:
+      for i in range(0, components):
+        sdp += self.create_candidate(i + 1, 'relay',
+                                     self.relay_ip, m_section['relay_port'] + i,
+                                     self.stun_ip, m_section['srflx_port'] + i)
+    return sdp
 
-candidate:109270924 1 udp 2122194687 192.168.2.3 61665 typ host
+  def create_m_sections(self, stype, mtype, formatter):
+    sdp = ''
+    num_components = 1
+    if self.mux_policy == 'negotiate' and stype == 'offer':
+      num_components = 2
+    for m_section in self.m_sections:
+      if m_section['type'] == mtype:
+        copy = m_section.copy()
+        copy['local_ip'] = self.local_ip
+        # tricky way to make rtcp port be rtp + 1, only if offering non-mux
+        copy['local_rtcp'] = copy['local_port'] + num_components - 1
+        copy['dtls_fingerprint'] = self.fingerprint
+        sdp += formatter.format(copy)
+        # only put transport attribs into non-bundled m= sections
+        if not 'bundled' in copy or not copy['bundled']:
+          # only add a=rtcp attribute if we're not sure we're muxing
+          if stype == 'offer':
+            sdp += self.TRANSPORT_SDP_WITH_RTCP.format(copy)
+          else:
+            sdp += self.TRANSPORT_SDP_NO_RTCP.format(copy)
+          # add candidates/eoc to SDP if we're not trickling
+          if not self.trickle:
+            sdp += self.create_candidates(copy, num_components)
+            sdp += self.END_OF_CANDIDATES_SDP
+    return sdp
 
-// candidate B4
+  def create_sdp(self, type):
+    self.version += 1
+    sdp = self.SESSION_SDP.format(self)
+    sdp += self.create_m_sections(type, 'audio', self.AUDIO_SDP)
+    sdp += self.create_m_sections(type ,'video', self.VIDEO_SDP)
+    sdp += self.create_m_sections(type, 'data', self.DATA_SDP)
+    # clean up the leading whitespace in the constants
+    sdp = sdp.replace('    ', '')
+    cands = []
+    return { 'type': type, 'sdp': sdp, 'candidates': cands }
+  def create_offer(self):
+    return self.create_sdp('offer')
+  def create_answer(self):
+    return self.create_sdp('answer')
 
-candidate:4036177504 1 udp 1685987071 55.66.77.88 64532 typ srflx
-          raddr 192.168.2.3 rport 61665
+def print_desc(d):
+  # wrap lines as needed
+  lines_pre = d['sdp'].split('\n')
+  lines_post = []
+  for line in lines_pre:
+    if line[:13] == 'a=fingerprint':
+      lines_post.append(line[:21])
+      lines_post.append(' ' * 14 + line[22:70])
+      lines_post.append(' ' * 14 + line[70:117])
+    else:
+      lines_post.append(line)
+  print '\n'.join(lines_post)
 
-// offer B2
+  candidates = d['candidates']
+  if len(candidates):
+    print 'Candidates:'
+    print candidates
+    print
 
-v=0
-o=- 7729291447651054566 2 IN IP4 0.0.0.0
-s=-
-t=0 0
-a=group:BUNDLE a1 d1 v1 v2
-a=ice-options:trickle
-m=audio 64532 UDP/TLS/RTP/SAVPF 96 0 8 97 98
-c=IN IP4 55.66.77.88
-a=rtcp:64532 IN IP4 55.66.77.88
-a=mid:a1
-a=msid:QI39StLS8W7ZbQl1sJsWUXkr3Zf12fJUvzQ1
-       QI39StLS8W7ZbQl1sJsWUXkr3Zf12fJUvzQ1a0
-a=sendrecv
-a=rtpmap:96 opus/48000/2
-a=rtpmap:0 PCMU/8000
-a=rtpmap:8 PCMA/8000
-a=rtpmap:97 telephone-event/8000
-a=rtpmap:98 telephone-event/48000
-a=maxptime:120
-a=ice-ufrag:7sFvz2gdLkEwjZEr
-a=ice-pwd:dOTZKZNVlO9RSGsEGM63JXT2
-a=fingerprint:sha-256 6B:8B:F0:65:5F:78:E2:51:3B:AC:6F:F3:3F:46:1B:35
-                     :DC:B8:5F:64:1A:24:C2:43:F0:A1:58:D0:A1:2C:19:08
-a=setup:actpass
-a=rtcp-mux
-a=rtcp-rsize
-a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
-a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
-a=candidate:109270924 1 udp 2122194687 192.168.2.3 61665 typ host
-a=candidate:4036177504 1 udp 1685987071 55.66.77.88 64532 typ srflx
-            raddr 192.168.2.3 rport 61665
-a=candidate:3671762467 1 udp 41819903 66.77.88.99 50416 typ relay
-            raddr 55.66.77.88 rport 64532
-a=end-of-candidates
+def example1():
+  ms1 = [
+    { 'type': 'audio', 'mid': 'a1',
+      'msid': '61317484-2ed4-49d7-9eb7-1414322a7aae',
+      'local_port': 56500, 'ice_ufrag': 'ETEn',
+      'ice_pwd': 'OtSK0WpNtpUjkY4+86js7ZQl', 'dtls_dir': 'actpass' },
+    { 'type': 'video', 'mid': 'v1',
+      'msid': '61317484-2ed4-49d7-9eb7-1414322a7aae',
+      'local_port': 56502, 'ice_ufrag': 'BGKk',
+      'ice_pwd': 'mqyWsAjvtKwTGnvhPztQ9mIf', 'dtls_dir': 'actpass' }
+  ]
+  fp1 = '19:E2:1C:3B:4B:9F:81:E6:B8:5C:F4:A5:A8:D8:73:04:BB:05:2F:70:9F:04:A9:0E:05:E9:26:33:E8:70:88:A2'
+  pc1 = PeerConnection(session_id = '4962303333179871722', trickle = False,
+                       bundle_policy = 'balanced', mux_policy = 'negotiate',
+                       local_ip = '192.0.2.1', stun_ip = None, relay_ip = None,
+                       fingerprint = fp1, m_sections = ms1)
 
-m=application 64532 UDP/DTLS/SCTP webrtc-datachannel
-c=IN IP4 55.66.77.88
-a=mid:d1
-a=fmtp:webrtc-datachannel max-message-size=65536
-a=sctp-port 5000
-a=ice-ufrag:7sFvz2gdLkEwjZEr
-a=ice-pwd:dOTZKZNVlO9RSGsEGM63JXT2
-a=fingerprint:sha-256 6B:8B:F0:65:5F:78:E2:51:3B:AC:6F:F3:3F:46:1B:35
-                     :DC:B8:5F:64:1A:24:C2:43:F0:A1:58:D0:A1:2C:19:08
-a=setup:actpass
-a=candidate:109270924 1 udp 2122194687 192.168.2.3 61665 typ host
-a=candidate:4036177504 1 udp 1685987071 55.66.77.88 64532 typ srflx
-            raddr 192.168.2.3 rport 61665
-a=candidate:3671762467 1 udp 41819903 66.77.88.99 50416 typ relay
-            raddr 55.66.77.88 rport 64532
-a=end-of-candidates
+  ms2 = [
+    { 'type': 'audio', 'mid': 'a1',
+      'msid': '5a7b57b8-f043-4bd1-a45d-09d4dfa31226',
+      'local_port': 34300, 'ice_ufrag': '6sFv',
+      'ice_pwd': 'cOTZKZNVlO9RSGsEGM63JXT2', 'dtls_dir': 'active' },
+    { 'type': 'video', 'mid': 'v1',
+      'msid': '4ea4d4a1-2fda-4511-a9cc-1b32c2e59552',
+      'local_port': 34300, 'bundled': True }
+  ]
+  fp2 = '6B:8B:F0:65:5F:78:E2:51:3B:AC:6F:F3:3F:46:1B:35:DC:B8:5F:64:1A:24:C2:43:F0:A1:58:D0:A1:2C:19:08'
+  pc2 = PeerConnection(session_id = '6729291447651054566', trickle = False,
+                       bundle_policy = 'balanced', mux_policy = 'negotiate',
+                       local_ip = '192.0.2.2', stun_ip = None, relay_ip = None,
+                       fingerprint = fp2, m_sections = ms2)
+  o = pc1.create_offer()
+  print 'The SDP for |offer-A1| looks like:\n\n'
+  print_desc(o)
+  print 'The SDP for |answer-A1| looks like:\n\n'
+  a = pc2.create_answer()
+  print_desc(a)
 
-m=video 0 UDP/TLS/RTP/SAVPF 100 101
-c=IN IP4 55.66.77.88
-a=bundle-only
-a=rtcp:64532 IN IP4 55.66.77.88
-a=mid:v1
-a=msid:61317484-2ed4-49d7-9eb7-1414322a7aae
-       f30bdb4a-5db8-49b5-bcdc-e0c9a23172e0
-a=sendrecv
-a=rtpmap:100 VP8/90000
-a=rtpmap:101 rtx/90000
-a=fmtp:101 apt=100
-a=fingerprint:sha-256
-              19:E2:1C:3B:4B:9F:81:E6:B8:5C:F4:A5:A8:D8:73:04
-             :BB:05:2F:70:9F:04:A9:0E:05:E9:26:33:E8:70:88:A2
-a=setup:actpass
-a=rtcp-mux
-a=rtcp-rsize
-a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
-a=rtcp-fb:100 ccm fir
-a=rtcp-fb:100 nack
-a=rtcp-fb:100 nack pli
+def example2():
+  pc1 = PeerConnection(trickle = True, bundle_policy = 'max-bundle',
+                       mux_policy = 'require')
+  pc2 = PeerConnection(trickle = False, bundle_policy = 'max-bundle',
+                       mux_policy = 'require')
+  o = pc1.create_offer()
+  print_desc(o)
+  a = pc2.create_answer()
+  print_desc(a)
 
-m=video 0 UDP/TLS/RTP/SAVPF 100 101
-c=IN IP4 55.66.77.88
-a=bundle-only
-a=rtcp:64532 IN IP4 55.66.77.88
-a=mid:v1
-a=msid:71317484-2ed4-49d7-9eb7-1414322a7aae
-       f30bdb4a-5db8-49b5-bcdc-e0c9a23172e0
-a=sendrecv
-a=rtpmap:100 VP8/90000
-a=rtpmap:101 rtx/90000
-a=fmtp:101 apt=100
-a=fingerprint:sha-256
-              19:E2:1C:3B:4B:9F:81:E6:B8:5C:F4:A5:A8:D8:73:04
-             :BB:05:2F:70:9F:04:A9:0E:05:E9:26:33:E8:70:88:A2
-a=setup:actpass
-a=rtcp-mux
-a=rtcp-rsize
-a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
-a=rtcp-fb:100 ccm fir
-a=rtcp-fb:100 nack
-a=rtcp-fb:100 nack pli
+  #pc1.m_sections.append(new_video)
+  o = pc2.create_offer()
+  print_desc(o)
+  a = pc1.create_answer()
+  print_desc(a)
 
-// answer B2
+if __name__ == '__main__':
+  example1()
+  #example2()
 
-v=0
-o=- 4962303333179871723 2 IN IP4 0.0.0.0
-s=-
-t=0 0
-a=group:BUNDLE a1 d1 v1 v2
-a=ice-options:trickle
-m=audio 52546 UDP/TLS/RTP/SAVPF 96 0 8 97 98
-c=IN IP4 11.22.33.44
-a=rtcp:52546 IN IP4 11.22.33.44
-a=mid:a1
-a=msid:57017fee-b6c1-4162-929c-a25110252400
-       e83006c5-a0ff-4e0a-9ed9-d3e6747be7d9
-a=sendrecv
-a=rtpmap:96 opus/48000/2
-a=rtpmap:0 PCMU/8000
-a=rtpmap:8 PCMA/8000
-a=rtpmap:97 telephone-event/8000
-a=rtpmap:98 telephone-event/48000
-a=maxptime:120
-a=ice-ufrag:ATEn1v9DoTMB9J4r
-a=ice-pwd:AtSK0WpNtpUjkY4+86js7ZQl
-a=fingerprint:sha-256
-              19:E2:1C:3B:4B:9F:81:E6:B8:5C:F4:A5:A8:D8:73:04
-             :BB:05:2F:70:9F:04:A9:0E:05:E9:26:33:E8:70:88:A2
-a=setup:passive
-a=rtcp-mux
-a=rtcp-rsize
-a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
-a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
-a=candidate:109270923 1 udp 2122194687 192.168.1.2 51556 typ host
-a=candidate:4036177503 1 udp 1685987071 11.22.33.44 52546 typ srflx
-            raddr 192.168.1.2 rport 51556
-a=candidate:3671762466 1 udp 41819903 22.33.44.55 61405 typ relay
-            raddr 11.22.33.44 rport 52546
-a=end-of-candidates
-
-m=application 52546 UDP/DTLS/SCTP webrtc-datachannel
-c=IN IP4 11.22.33.44
-a=mid:d1
-a=fmtp:webrtc-datachannel max-message-size=65536
-a=sctp-port 5000
-a=fingerprint:sha-256 19:E2:1C:3B:4B:9F:81:E6:B8:5C:F4:A5:A8:D8:73:04
-                     :BB:05:2F:70:9F:04:A9:0E:05:E9:26:33:E8:70:88:A2
-a=setup:passive
-
-m=video 52546 UDP/TLS/RTP/SAVPF 100 101
-c=IN IP4 11.22.33.44
-a=rtcp:52546 IN IP4 11.22.33.44
-a=mid:v1
-a=recvonly
-a=rtpmap:100 VP8/90000
-a=rtpmap:101 rtx/90000
-a=fmtp:101 apt=100
-a=fingerprint:sha-256
-              19:E2:1C:3B:4B:9F:81:E6:B8:5C:F4:A5:A8:D8:73:04
-             :BB:05:2F:70:9F:04:A9:0E:05:E9:26:33:E8:70:88:A2
-a=setup:passive
-a=rtcp-mux
-a=rtcp-rsize
-a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
-a=rtcp-fb:100 ccm fir
-a=rtcp-fb:100 nack
-a=rtcp-fb:100 nack pli
-
-m=video 52546 UDP/TLS/RTP/SAVPF 100 101
-c=IN IP4 11.22.33.44
-a=rtcp:52546 IN IP4 11.22.33.44
-a=mid:v2
-a=recvonly
-a=rtpmap:100 VP8/90000
-a=rtpmap:101 rtx/90000
-a=fmtp:101 apt=100
-a=fingerprint:sha-256
-              19:E2:1C:3B:4B:9F:81:E6:B8:5C:F4:A5:A8:D8:73:04
-             :BB:05:2F:70:9F:04:A9:0E:05:E9:26:33:E8:70:88:A2
-a=setup:passive
-a=rtcp-mux
-a=rtcp-rsize
-a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
-a=rtcp-fb:100 ccm fir
-a=rtcp-fb:100 nack
-a=rtcp-fb:100 nack pli

--- a/gen_examples.py
+++ b/gen_examples.py
@@ -176,6 +176,7 @@ def print_desc(d):
     else:
       lines_post.append(line)
   print '\n'.join(lines_post)
+  # TODO: Add line breaks between m= sections
 
   candidates = d['candidates']
   if len(candidates):

--- a/gen_examples.py
+++ b/gen_examples.py
@@ -40,8 +40,8 @@ class PeerConnection:
     a=rtpmap:97 telephone-event/8000
     a=rtpmap:98 telephone-event/48000
     a=maxptime:120
-    a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
-    a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
+    a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid
+    a=extmap:2 urn:ietf:params:rtp-hdrext:ssrc-audio-level
     a=msid:{0[ms]} {0[mst]}
     """
   # TODO: proper default candidate in c=, m=, rtcp lines
@@ -54,7 +54,7 @@ class PeerConnection:
     a=rtpmap:100 VP8/90000
     a=rtpmap:101 rtx/90000
     a=fmtp:101 apt=100
-    a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:mid
+    a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid
     a=rtcp-fb:100 ccm fir
     a=rtcp-fb:100 nack
     a=rtcp-fb:100 nack pli

--- a/gen_examples.py
+++ b/gen_examples.py
@@ -186,7 +186,7 @@ def print_desc(d):
 def example1():
   ms1 = [
     { 'type': 'audio', 'mid': 'a1',
-      'msid': '61317484-2ed4-49d7-9eb7-1414322a7aae',
+      'msid': '47017fee-b6c1-4162-929c-a25110252400',
       'local_port': 56500, 'ice_ufrag': 'ETEn',
       'ice_pwd': 'OtSK0WpNtpUjkY4+86js7ZQl', 'dtls_dir': 'actpass' },
     { 'type': 'video', 'mid': 'v1',

--- a/gen_examples.py
+++ b/gen_examples.py
@@ -1,0 +1,397 @@
+offer_a1 = """
+  v=0
+  o=- 4962303333179871722 1 IN IP4 0.0.0.0
+  s=-
+  t=0 0
+  a=group:BUNDLE a1 v1
+  a=ice-options:trickle
+  m=audio 56500 UDP/TLS/RTP/SAVPF 96 0 8 97 98
+  c=IN IP4 192.0.2.1
+  a=mid:a1
+  a=rtcp:56501 IN IP4 192.0.2.1
+  a=msid:47017fee-b6c1-4162-929c-a25110252400
+         f83006c5-a0ff-4e0a-9ed9-d3e6747be7d9
+  a=sendrecv
+  a=rtpmap:96 opus/48000/2
+  a=rtpmap:0 PCMU/8000
+  a=rtpmap:8 PCMA/8000
+  a=rtpmap:97 telephone-event/8000
+  a=rtpmap:98 telephone-event/48000
+  a=maxptime:120
+  a=ice-ufrag:ETEn1v9DoTMB9J4r
+  a=ice-pwd:OtSK0WpNtpUjkY4+86js7ZQl
+  a=fingerprint:sha-256
+                19:E2:1C:3B:4B:9F:81:E6:B8:5C:F4:A5:A8:D8:73:04
+               :BB:05:2F:70:9F:04:A9:0E:05:E9:26:33:E8:70:88:A2
+  a=setup:actpass
+  a=rtcp-mux
+  a=rtcp-rsize
+  a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
+  a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
+  a=candidate:3348148302 1 udp 2113937151 192.0.2.1 56500
+              typ host
+  a=candidate:3348148302 2 udp 2113937151 192.0.2.1 56501
+              typ host
+  a=end-of-candidates
+
+  m=video 56502 UDP/TLS/RTP/SAVPF 100 101
+  c=IN IP4 192.0.2.1
+  a=rtcp:56503 IN IP4 192.0.2.1
+  a=mid:v1
+  a=msid:61317484-2ed4-49d7-9eb7-1414322a7aae
+         f30bdb4a-5db8-49b5-bcdc-e0c9a23172e0
+  a=sendrecv
+  a=rtpmap:100 VP8/90000
+  a=rtpmap:101 rtx/90000
+  a=fmtp:101 apt=100
+  a=ice-ufrag:BGKkWnG5GmiUpdIV
+  a=ice-pwd:mqyWsAjvtKwTGnvhPztQ9mIf
+  a=fingerprint:sha-256
+                19:E2:1C:3B:4B:9F:81:E6:B8:5C:F4:A5:A8:D8:73:04
+               :BB:05:2F:70:9F:04:A9:0E:05:E9:26:33:E8:70:88:A2
+  a=setup:actpass
+  a=rtcp-mux
+  a=rtcp-rsize
+  a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:mid
+  a=rtcp-fb:100 ccm fir
+  a=rtcp-fb:100 nack
+  a=rtcp-fb:100 nack pli
+  a=candidate:3348148302 1 udp 2113937151 192.0.2.1 56502
+              typ host
+  a=candidate:3348148302 2 udp 2113937151 192.0.2.1 56503
+              typ host
+  a=end-of-candidates
+"""
+
+answer_a1 =
+"""
+  v=0
+  o=- 6729291447651054566 1 IN IP4 0.0.0.0
+  s=-
+  t=0 0
+  a=group:BUNDLE a1 v1
+  m=audio 20000 UDP/TLS/RTP/SAVPF 96 0 8 97 98
+  c=IN IP4 192.0.2.2
+  a=mid:a1
+  a=rtcp:20000 IN IP4 192.0.2.2
+  a=msid:PI39StLS8W7ZbQl1sJsWUXkr3Zf12fJUvzQ1
+         PI39StLS8W7ZbQl1sJsWUXkr3Zf12fJUvzQ1a0
+  a=sendrecv
+  a=rtpmap:96 opus/48000/2
+  a=rtpmap:0 PCMU/8000
+  a=rtpmap:8 PCMA/8000
+  a=rtpmap:97 telephone-event/8000
+  a=rtpmap:98 telephone-event/48000
+  a=maxptime:120
+  a=ice-ufrag:6sFvz2gdLkEwjZEr
+  a=ice-pwd:cOTZKZNVlO9RSGsEGM63JXT2
+  a=fingerprint:sha-256 6B:8B:F0:65:5F:78:E2:51:3B:AC:6F:F3:3F:46:1B:35
+              :DC:B8:5F:64:1A:24:C2:43:F0:A1:58:D0:A1:2C:19:08
+  a=setup:active
+  a=rtcp-mux
+  a=rtcp-rsize
+  a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
+  a=candidate:2299743422 1 udp 2113937151 192.0.2.2 20000
+              typ host
+  a=end-of-candidates
+
+  m=video 20000 UDP/TLS/RTP/SAVPF 100 101
+  c=IN IP4 192.0.2.2
+  a=rtcp 20001 IN IP4 192.0.2.2
+  a=mid:v1
+  a=msid:PI39StLS8W7ZbQl1sJsWUXkr3Zf12fJUvzQ1
+         PI39StLS8W7ZbQl1sJsWUXkr3Zf12fJUvzQ1v0
+  a=sendrecv
+  a=rtpmap:100 VP8/90000
+  a=rtpmap:101 rtx/90000
+  a=fmtp:101 apt=100
+  a=fingerprint:sha-256 6B:8B:F0:65:5F:78:E2:51:3B:AC:6F:F3:3F:46:1B:35
+                       :DC:B8:5F:64:1A:24:C2:43:F0:A1:58:D0:A1:2C:19:08
+  a=setup:active
+  a=rtcp-mux
+  a=rtcp-rsize
+  a=rtcp-fb:100 ccm fir
+  a=rtcp-fb:100 nack
+  a=rtcp-fb:100 nack pli
+"""
+
+offer_b1 = """
+  v=0
+  o=- 4962303333179871723 1 IN IP4 0.0.0.0
+  s=-
+  t=0 0
+  a=group:BUNDLE a1 d1
+  a=ice-options:trickle
+  m=audio 9 UDP/TLS/RTP/SAVPF 96 0 8 97 98
+  c=IN IP4 0.0.0.0
+  a=rtcp:9 IN IP4 0.0.0.0
+  a=mid:a1
+  a=msid:57017fee-b6c1-4162-929c-a25110252400
+         e83006c5-a0ff-4e0a-9ed9-d3e6747be7d9
+  a=sendrecv
+  a=rtpmap:96 opus/48000/2
+  a=rtpmap:0 PCMU/8000
+  a=rtpmap:8 PCMA/8000
+  a=rtpmap:97 telephone-event/8000
+  a=rtpmap:98 telephone-event/48000
+  a=maxptime:120
+  a=ice-ufrag:ATEn1v9DoTMB9J4r
+  a=ice-pwd:AtSK0WpNtpUjkY4+86js7ZQl
+  a=fingerprint:sha-256
+                19:E2:1C:3B:4B:9F:81:E6:B8:5C:F4:A5:A8:D8:73:04
+               :BB:05:2F:70:9F:04:A9:0E:05:E9:26:33:E8:70:88:A2
+  a=setup:actpass
+  a=rtcp-mux
+  a=rtcp-rsize
+  a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
+  a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
+
+  m=application 0 UDP/DTLS/SCTP webrtc-datachannel
+  c=IN IP4 0.0.0.0
+  a=bundle-only
+  a=mid:d1
+  a=fmtp:webrtc-datachannel max-message-size=65536
+  a=sctp-port 5000
+  a=fingerprint:sha-256 19:E2:1C:3B:4B:9F:81:E6:B8:5C:F4:A5:A8:D8:73:04
+                       :BB:05:2F:70:9F:04:A9:0E:05:E9:26:33:E8:70:88:A2
+  a=setup:actpass
+"""
+
+candidate_b1 = """
+  candidate:109270923 1 udp 2122194687 192.168.1.2 51556 typ host
+"""
+
+candidate_b2 = """
+  candidate:4036177503 1 udp 1685987071 11.22.33.44 52546 typ srflx
+            raddr 192.168.1.2 rport 51556
+"""
+
+answer_b1 = """
+o=- 7729291447651054566 1 IN IP4 0.0.0.0
+s=-
+t=0 0
+a=group:BUNDLE a1 d1
+a=ice-options:trickle
+m=audio 9 UDP/TLS/RTP/SAVPF 96 0 8 97 98
+c=IN IP4 0.0.0.0
+a=rtcp:9 IN IP4 0.0.0.0
+a=mid:a1
+a=msid:QI39StLS8W7ZbQl1sJsWUXkr3Zf12fJUvzQ1
+       QI39StLS8W7ZbQl1sJsWUXkr3Zf12fJUvzQ1a0
+a=sendrecv
+a=rtpmap:96 opus/48000/2
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=rtpmap:97 telephone-event/8000
+a=rtpmap:98 telephone-event/48000
+a=maxptime:120
+a=ice-ufrag:7sFvz2gdLkEwjZEr
+a=ice-pwd:dOTZKZNVlO9RSGsEGM63JXT2
+a=fingerprint:sha-256 6B:8B:F0:65:5F:78:E2:51:3B:AC:6F:F3:3F:46:1B:35
+                     :DC:B8:5F:64:1A:24:C2:43:F0:A1:58:D0:A1:2C:19:08
+a=setup:active
+a=rtcp-mux
+a=rtcp-rsize
+a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
+a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
+
+m=application 9 UDP/DTLS/SCTP webrtc-datachannel
+c=IN IP4 0.0.0.0
+a=mid:d1
+a=fmtp:webrtc-datachannel max-message-size=65536
+a=sctp-port 5000
+a=fingerprint:sha-256 6B:8B:F0:65:5F:78:E2:51:3B:AC:6F:F3:3F:46:1B:35
+                     :DC:B8:5F:64:1A:24:C2:43:F0:A1:58:D0:A1:2C:19:08
+a=setup:active
+
+// candidate B3
+
+candidate:109270924 1 udp 2122194687 192.168.2.3 61665 typ host
+
+// candidate B4
+
+candidate:4036177504 1 udp 1685987071 55.66.77.88 64532 typ srflx
+          raddr 192.168.2.3 rport 61665
+
+// offer B2
+
+v=0
+o=- 7729291447651054566 2 IN IP4 0.0.0.0
+s=-
+t=0 0
+a=group:BUNDLE a1 d1 v1 v2
+a=ice-options:trickle
+m=audio 64532 UDP/TLS/RTP/SAVPF 96 0 8 97 98
+c=IN IP4 55.66.77.88
+a=rtcp:64532 IN IP4 55.66.77.88
+a=mid:a1
+a=msid:QI39StLS8W7ZbQl1sJsWUXkr3Zf12fJUvzQ1
+       QI39StLS8W7ZbQl1sJsWUXkr3Zf12fJUvzQ1a0
+a=sendrecv
+a=rtpmap:96 opus/48000/2
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=rtpmap:97 telephone-event/8000
+a=rtpmap:98 telephone-event/48000
+a=maxptime:120
+a=ice-ufrag:7sFvz2gdLkEwjZEr
+a=ice-pwd:dOTZKZNVlO9RSGsEGM63JXT2
+a=fingerprint:sha-256 6B:8B:F0:65:5F:78:E2:51:3B:AC:6F:F3:3F:46:1B:35
+                     :DC:B8:5F:64:1A:24:C2:43:F0:A1:58:D0:A1:2C:19:08
+a=setup:actpass
+a=rtcp-mux
+a=rtcp-rsize
+a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
+a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
+a=candidate:109270924 1 udp 2122194687 192.168.2.3 61665 typ host
+a=candidate:4036177504 1 udp 1685987071 55.66.77.88 64532 typ srflx
+            raddr 192.168.2.3 rport 61665
+a=candidate:3671762467 1 udp 41819903 66.77.88.99 50416 typ relay
+            raddr 55.66.77.88 rport 64532
+a=end-of-candidates
+
+m=application 64532 UDP/DTLS/SCTP webrtc-datachannel
+c=IN IP4 55.66.77.88
+a=mid:d1
+a=fmtp:webrtc-datachannel max-message-size=65536
+a=sctp-port 5000
+a=ice-ufrag:7sFvz2gdLkEwjZEr
+a=ice-pwd:dOTZKZNVlO9RSGsEGM63JXT2
+a=fingerprint:sha-256 6B:8B:F0:65:5F:78:E2:51:3B:AC:6F:F3:3F:46:1B:35
+                     :DC:B8:5F:64:1A:24:C2:43:F0:A1:58:D0:A1:2C:19:08
+a=setup:actpass
+a=candidate:109270924 1 udp 2122194687 192.168.2.3 61665 typ host
+a=candidate:4036177504 1 udp 1685987071 55.66.77.88 64532 typ srflx
+            raddr 192.168.2.3 rport 61665
+a=candidate:3671762467 1 udp 41819903 66.77.88.99 50416 typ relay
+            raddr 55.66.77.88 rport 64532
+a=end-of-candidates
+
+m=video 0 UDP/TLS/RTP/SAVPF 100 101
+c=IN IP4 55.66.77.88
+a=bundle-only
+a=rtcp:64532 IN IP4 55.66.77.88
+a=mid:v1
+a=msid:61317484-2ed4-49d7-9eb7-1414322a7aae
+       f30bdb4a-5db8-49b5-bcdc-e0c9a23172e0
+a=sendrecv
+a=rtpmap:100 VP8/90000
+a=rtpmap:101 rtx/90000
+a=fmtp:101 apt=100
+a=fingerprint:sha-256
+              19:E2:1C:3B:4B:9F:81:E6:B8:5C:F4:A5:A8:D8:73:04
+             :BB:05:2F:70:9F:04:A9:0E:05:E9:26:33:E8:70:88:A2
+a=setup:actpass
+a=rtcp-mux
+a=rtcp-rsize
+a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
+a=rtcp-fb:100 ccm fir
+a=rtcp-fb:100 nack
+a=rtcp-fb:100 nack pli
+
+m=video 0 UDP/TLS/RTP/SAVPF 100 101
+c=IN IP4 55.66.77.88
+a=bundle-only
+a=rtcp:64532 IN IP4 55.66.77.88
+a=mid:v1
+a=msid:71317484-2ed4-49d7-9eb7-1414322a7aae
+       f30bdb4a-5db8-49b5-bcdc-e0c9a23172e0
+a=sendrecv
+a=rtpmap:100 VP8/90000
+a=rtpmap:101 rtx/90000
+a=fmtp:101 apt=100
+a=fingerprint:sha-256
+              19:E2:1C:3B:4B:9F:81:E6:B8:5C:F4:A5:A8:D8:73:04
+             :BB:05:2F:70:9F:04:A9:0E:05:E9:26:33:E8:70:88:A2
+a=setup:actpass
+a=rtcp-mux
+a=rtcp-rsize
+a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
+a=rtcp-fb:100 ccm fir
+a=rtcp-fb:100 nack
+a=rtcp-fb:100 nack pli
+
+// answer B2
+
+v=0
+o=- 4962303333179871723 2 IN IP4 0.0.0.0
+s=-
+t=0 0
+a=group:BUNDLE a1 d1 v1 v2
+a=ice-options:trickle
+m=audio 52546 UDP/TLS/RTP/SAVPF 96 0 8 97 98
+c=IN IP4 11.22.33.44
+a=rtcp:52546 IN IP4 11.22.33.44
+a=mid:a1
+a=msid:57017fee-b6c1-4162-929c-a25110252400
+       e83006c5-a0ff-4e0a-9ed9-d3e6747be7d9
+a=sendrecv
+a=rtpmap:96 opus/48000/2
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=rtpmap:97 telephone-event/8000
+a=rtpmap:98 telephone-event/48000
+a=maxptime:120
+a=ice-ufrag:ATEn1v9DoTMB9J4r
+a=ice-pwd:AtSK0WpNtpUjkY4+86js7ZQl
+a=fingerprint:sha-256
+              19:E2:1C:3B:4B:9F:81:E6:B8:5C:F4:A5:A8:D8:73:04
+             :BB:05:2F:70:9F:04:A9:0E:05:E9:26:33:E8:70:88:A2
+a=setup:passive
+a=rtcp-mux
+a=rtcp-rsize
+a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level
+a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
+a=candidate:109270923 1 udp 2122194687 192.168.1.2 51556 typ host
+a=candidate:4036177503 1 udp 1685987071 11.22.33.44 52546 typ srflx
+            raddr 192.168.1.2 rport 51556
+a=candidate:3671762466 1 udp 41819903 22.33.44.55 61405 typ relay
+            raddr 11.22.33.44 rport 52546
+a=end-of-candidates
+
+m=application 52546 UDP/DTLS/SCTP webrtc-datachannel
+c=IN IP4 11.22.33.44
+a=mid:d1
+a=fmtp:webrtc-datachannel max-message-size=65536
+a=sctp-port 5000
+a=fingerprint:sha-256 19:E2:1C:3B:4B:9F:81:E6:B8:5C:F4:A5:A8:D8:73:04
+                     :BB:05:2F:70:9F:04:A9:0E:05:E9:26:33:E8:70:88:A2
+a=setup:passive
+
+m=video 52546 UDP/TLS/RTP/SAVPF 100 101
+c=IN IP4 11.22.33.44
+a=rtcp:52546 IN IP4 11.22.33.44
+a=mid:v1
+a=recvonly
+a=rtpmap:100 VP8/90000
+a=rtpmap:101 rtx/90000
+a=fmtp:101 apt=100
+a=fingerprint:sha-256
+              19:E2:1C:3B:4B:9F:81:E6:B8:5C:F4:A5:A8:D8:73:04
+             :BB:05:2F:70:9F:04:A9:0E:05:E9:26:33:E8:70:88:A2
+a=setup:passive
+a=rtcp-mux
+a=rtcp-rsize
+a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
+a=rtcp-fb:100 ccm fir
+a=rtcp-fb:100 nack
+a=rtcp-fb:100 nack pli
+
+m=video 52546 UDP/TLS/RTP/SAVPF 100 101
+c=IN IP4 11.22.33.44
+a=rtcp:52546 IN IP4 11.22.33.44
+a=mid:v2
+a=recvonly
+a=rtpmap:100 VP8/90000
+a=rtpmap:101 rtx/90000
+a=fmtp:101 apt=100
+a=fingerprint:sha-256
+              19:E2:1C:3B:4B:9F:81:E6:B8:5C:F4:A5:A8:D8:73:04
+             :BB:05:2F:70:9F:04:A9:0E:05:E9:26:33:E8:70:88:A2
+a=setup:passive
+a=rtcp-mux
+a=rtcp-rsize
+a=extmap:2 urn:ietf:params:rtp-hdrext:sdes:mid
+a=rtcp-fb:100 ccm fir
+a=rtcp-fb:100 nack
+a=rtcp-fb:100 nack pli

--- a/tools/tester.js
+++ b/tools/tester.js
@@ -1,16 +1,16 @@
 function canonicalize(sdp) {
     let lines = sdp.split("\n");
     let output = "";
-        
+
     for (l in lines) {
         let trimmed = lines[l].trim()
         if (lines[l].length === 0) {
             continue;
         }
         if (lines[l].startsWith(' ')) {
-            // Line folding
-            if (!trimmed.startsWith(':')) {
-                output += ' ';
+            // Line folding; add a space unless this is a fingerprint.
+            if (!lines[l - 1].endsWith(':')) {
+                 output += ' ';
             }
         } else if (output.length > 0) {
             // No line folding and not first line.
@@ -25,9 +25,9 @@ function test() {
     let sdp = document.getElementById("offer").value;
     console.log("Original SDP" + sdp);
     let canon = canonicalize(sdp);
-    
+
     console.log("Canonical SDP:" + canon);
-    
+
     let pc = new RTCPeerConnection();
     pc.setRemoteDescription(
         {


### PR DESCRIPTION
Python generator for SDP. Super simplified for the purposes of our examples, but should be reasonably flexible. Right now it only generates the simple example.

Changes to the document:
- session attribs ordering now match text
- a=msid format now matches latest spec (I think)
- use GUIDs for MSIDs consistently
- use short ufrags, as one should
- group transport attribs together
- tweak indenting of fingerprint attrib
- Add support for dtls-id
- Only include a=rtcp in offers (I think this is right)
- Use simpler candidate foundations
- pick a more interesting port for the answer

Relevant to #298 and #356.