### PR TITLE
Describe how "a=msid" should be generated when there's no track/stream.

### DIFF
--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -2097,8 +2097,8 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
                 the "a=msid" lines MUST use that track's ID. If no
                 MediaStreamTrack is attached, a valid ID MUST be generated
                 instead. To avoid fingerprinting, it is RECOMMENDED to generate
-                a UUID <xref target="RFC4122"></xref> using a form in section
-                4.4 or 4.5 of RFC 4122.</t>
+                a UUID <xref target="RFC4122"></xref> using the form in section
+                4.4 of RFC 4122.</t>
               </list></t>
 
               <t>If the RtpTransceiver has a sendrecv or sendonly

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -2089,9 +2089,16 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
               direction:
               <list style="symbols">
 
-                <t>An "a=msid" line, as specified in
-                <xref target="I-D.ietf-mmusic-msid"></xref>, Section
-                2.</t>
+                <t>For each MediaStream that was associated with the
+                transceiver when it was created via addTrack or addTransceiver,
+                an "a=msid" line, as specified in
+                <xref target="I-D.ietf-mmusic-msid"></xref>, Section 2. If a
+                MediaStreamTrack is attached to the transceiver's RtpSender,
+                the "a=msid" lines MUST use that track's ID. If no
+                MediaStreamTrack is attached, a valid ID MUST be generated
+                instead. To avoid fingerprinting, it is RECOMMENDED to generate
+                a UUID <xref target="RFC4122"></xref> using a form in section
+                4.4 or 4.5 of RFC 4122.</t>
               </list></t>
 
               <t>If the RtpTransceiver has a sendrecv or sendonly
@@ -5321,6 +5328,27 @@ a=rtcp-fb:100 nack pli
 
         <seriesInfo name="Internet-Draft" value="draft-ietf-mmusic-dtls-sdp-14"/>
         <format type="TXT" target="http://www.ietf.org/internet-drafts/draft-ietf-mmusic-dtls-sdp-14.txt"/>
+      </reference>
+      <reference anchor="RFC4122">
+        <front>
+          <title>A Universally Unique IDentifier (UUID) URN Namespace</title>
+          <author fullname="P. Leach" initials="P." surname="Leach">
+            <organization></organization>
+          </author>
+          <author fullname="M. Mealling" initials="M."
+          surname="Mealling">
+            <organization></organization>
+          </author>
+          <author fullname="R. Salz" initials="R."
+          surname="Salz">
+            <organization></organization>
+          </author>
+          <date month="July" year="2005" />
+        </front>
+        <seriesInfo name="RFC" value="4122" />
+        <format octets="53319"
+        target="http://www.rfc-editor.org/rfc/rfc4122.txt"
+        type="TXT" />
       </reference>
 
     </references>

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -2312,7 +2312,11 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
 
             <t>For RtpTransceivers that are not stopped, the "a=msid"
             line(s) MUST stay the same if
-            they are present in the current description.</t>
+            they are present in the current description, regardless of
+            changes to the transceiver's direction or track. If no
+            "a=msid" line is present in the current description,
+            "a=msid" line(s) MUST be generated according to the same
+            rules as for an initial offer.</t>
 
             <t>Each "m=" and c=" line MUST be filled in with the port,
             protocol, and address of the default candidate for the m=
@@ -2356,9 +2360,6 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             If the m= section is bundled into another m= section, both
             "a=candidate" and "a=end-of-candidates" MUST be
             omitted.</t>
-
-            <t>For RtpTransceivers that are still present, the
-            "a=msid" line(s) MUST stay the same.</t>
 
             <t>For RtpTransceivers that are still present, the "a=rid"
             lines MUST stay the same.</t>
@@ -2854,7 +2855,11 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             omitted.</t>
 
             <t>For RtpTransceivers that are not stopped, the "a=msid"
-            line(s) MUST stay the same.</t>
+            line(s) MUST stay the same, regardless of
+            changes to the transceiver's direction or track. If no
+            "a=msid" line is present in the current description,
+            "a=msid" line(s) MUST be generated according to the same
+            rules as for an initial answer.</t>
           </list></t>
         </section>
         <section title="Options Handling"

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -2688,9 +2688,15 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             <t>If the RtpTransceiver has a sendrecv or sendonly direction:
             <list style="symbols">
 
-              <t>An "a=msid" line, as specified in
-              <xref target="I-D.ietf-mmusic-msid"></xref>, Section
-              2.</t>
+              <t>For each MediaStream that was associated with the
+              transceiver when it was created via addTrack or addTransceiver,
+              an "a=msid" line, as specified in
+              <xref target="I-D.ietf-mmusic-msid"></xref>, Section 2. If a
+              MediaStreamTrack is attached to the transceiver's RtpSender,
+              the "a=msid" lines MUST use that track's ID. If no
+              MediaStreamTrack is attached, a valid ID MUST be generated,
+              in the same way that the implementation generates IDs for
+              local tracks.</t>
             </list></t>
           </list></t>
 

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -2098,6 +2098,12 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
                 MediaStreamTrack is attached, a valid ID MUST be generated,
                 in the same way that the implementation generates IDs for
                 local tracks.</t>
+
+                <t>If no MediaStream is associated with the transceiver, a
+                single "a=msid" line with the special value "-" in place of
+                the MediaStream ID, as specified in <xref
+                target="I-D.ietf-mmusic-msid"></xref>, Section 3. The track
+                ID MUST be selected as described above.</t>
               </list></t>
 
               <t>If the RtpTransceiver has a sendrecv or sendonly
@@ -2301,11 +2307,11 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             <t>If an RtpTransceiver has been stopped and is associated
             with an m= section, and the m= section is not being
             recycled as described above, an m= section MUST be
-            generated for it with the port set to zero and the
-            "a=msid" line removed.</t>
+            generated for it with the port set to zero and all
+            "a=msid" lines removed.</t>
 
             <t>For RtpTransceivers that are not stopped, the "a=msid"
-            line MUST stay the same if
+            line(s) MUST stay the same if
             they are present in the current description.</t>
 
             <t>Each "m=" and c=" line MUST be filled in with the port,
@@ -2352,7 +2358,7 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             omitted.</t>
 
             <t>For RtpTransceivers that are still present, the
-            "a=msid" line MUST stay the same.</t>
+            "a=msid" line(s) MUST stay the same.</t>
 
             <t>For RtpTransceivers that are still present, the "a=rid"
             lines MUST stay the same.</t>
@@ -2361,8 +2367,8 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             "a=simulcast" line MUST stay the same.</t>
 
             <t>If any RtpTransceiver has been stopped, the port MUST be
-            set to zero and the "a=msid"
-            line MUST be removed.</t>
+            set to zero and all "a=msid"
+            lines MUST be removed.</t>
 
             <t>If any RtpTransceiver has been added, and there exists a
             m= section with a zero port in the current local
@@ -2697,6 +2703,12 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
               MediaStreamTrack is attached, a valid ID MUST be generated,
               in the same way that the implementation generates IDs for
               local tracks.</t>
+
+              <t>If no MediaStream is associated with the transceiver, a
+              single "a=msid" line with the special value "-" in place of
+              the MediaStream ID, as specified in <xref
+              target="I-D.ietf-mmusic-msid"></xref>, Section 3. The track
+              ID MUST be selected as described above.</t>
             </list></t>
           </list></t>
 
@@ -2842,7 +2854,7 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             omitted.</t>
 
             <t>For RtpTransceivers that are not stopped, the "a=msid"
-            line MUST stay the same.</t>
+            line(s) MUST stay the same.</t>
           </list></t>
         </section>
         <section title="Options Handling"
@@ -3227,10 +3239,10 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             ignored, as this information is superfluous when using
             ICE.</t>
 
-            <t>If present, a single "a=msid" attribute MUST be parsed
+            <t>If present, "a=msid" attributes MUST be parsed
             as specified in
             <xref target="I-D.ietf-mmusic-msid" />, Section 3.2, and
-            its value stored.</t>
+            their values stored.</t>
 
             <t>Any "a=imageattr" attributes MUST be parsed as specified
             in

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -2095,10 +2095,9 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
                 <xref target="I-D.ietf-mmusic-msid"></xref>, Section 2. If a
                 MediaStreamTrack is attached to the transceiver's RtpSender,
                 the "a=msid" lines MUST use that track's ID. If no
-                MediaStreamTrack is attached, a valid ID MUST be generated
-                instead. To avoid fingerprinting, it is RECOMMENDED to generate
-                a UUID <xref target="RFC4122"></xref> using the form in section
-                4.4 of RFC 4122.</t>
+                MediaStreamTrack is attached, a valid ID MUST be generated,
+                in the same way that the implementation generates IDs for
+                local tracks.</t>
               </list></t>
 
               <t>If the RtpTransceiver has a sendrecv or sendonly
@@ -5328,27 +5327,6 @@ a=rtcp-fb:100 nack pli
 
         <seriesInfo name="Internet-Draft" value="draft-ietf-mmusic-dtls-sdp-14"/>
         <format type="TXT" target="http://www.ietf.org/internet-drafts/draft-ietf-mmusic-dtls-sdp-14.txt"/>
-      </reference>
-      <reference anchor="RFC4122">
-        <front>
-          <title>A Universally Unique IDentifier (UUID) URN Namespace</title>
-          <author fullname="P. Leach" initials="P." surname="Leach">
-            <organization></organization>
-          </author>
-          <author fullname="M. Mealling" initials="M."
-          surname="Mealling">
-            <organization></organization>
-          </author>
-          <author fullname="R. Salz" initials="R."
-          surname="Salz">
-            <organization></organization>
-          </author>
-          <date month="July" year="2005" />
-        </front>
-        <seriesInfo name="RFC" value="4122" />
-        <format octets="53319"
-        target="http://www.rfc-editor.org/rfc/rfc4122.txt"
-        type="TXT" />
       </reference>
 
     </references>


### PR DESCRIPTION
Fixes #507 and #586

Suggesting the same thing as mediacapture-streams, which is to generate
UUIDs using the forms in section 4.4 or 4.5 of RFC4122.