### PR TITLE
PT check needed on SSRC match

### DIFF
--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -5832,8 +5832,10 @@ a=rtcp-fb:100 nack pli
           "m=" line for that MID.</t>
 
           <t>If the packet's SSRC is in the incoming SSRC mapping
-          table, route the packet to the associated "m=" line and
-          stop.</t>
+          table, check that the packet's PT matches a PT included
+          on the associated "m=" line.  If so, route the packet to
+          that associated "m=" line and stop, otherwise drop the
+          packet.</t>
 
           <t>If the packet's payload type is in the payload type
           table, update the the incoming SSRC mapping table to include


### PR DESCRIPTION
After an SSRC match, need to check that the packet.PT matches a PT for the "m=" line.

Related to Issue https://github.com/rtcweb-wg/jsep/issues/367