### PR TITLE
Editorial cleanup of RTCP rules

### DIFF
--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -5598,7 +5598,7 @@ a=rtcp-fb:100 nack pli
         <seriesInfo name='RFC' value='5104'/>
         <seriesInfo name='DOI' value='10.17487/RFC5104'/>
       </reference>
-	 
+
       <!-- INFORM 18 -->
       <reference  anchor='RFC3550' target='http://www.rfc-editor.org/info/rfc3550'>
 	<front>
@@ -5767,14 +5767,14 @@ a=rtcp-fb:100 nack pli
       <t>
         In order for an offerer and answerer to always be able to associate an RTP stream
         with the correct "m=" line, the offerer and answerer using the BUNDLE extension MUST
-        support the mechanism defined in <xref target="I-D.ietf-mmusic-sdp-bundle-negotiation" /> section 14.
+        support the mechanism defined in <xref target="I-D.ietf-mmusic-sdp-bundle-negotiation" />, Section 14.
         where the offerer and answerer insert the identification-tag
         associated with an "m=" line (provided by the remote peer)
 	into RTP and RTCP packets associated with a BUNDLE group.
       </t>
       <t>
         The mapping from an SSRC to an identification-tag is carried in RTCP
-        SDES packets or in RTP header extensions (<xref target="I-D.ietf-mmusic-sdp-bundle-negotiation" /> section 14).
+        SDES packets or in RTP header extensions (<xref target="I-D.ietf-mmusic-sdp-bundle-negotiation" />, Section 14).
 	Since a compound RTCP packet can contain multiple
         RTCP SDES packets, and each RTCP SDES packet can contain multiple chunks, an
         RTCP packet can contain several SSRC to identification-tag mappings. The offerer
@@ -5884,20 +5884,20 @@ a=rtcp-fb:100 nack pli
           <t>If the packet is of type BYE, for each SSRC indicated in the
           packet that is found in the incoming SSRC table, deliver a copy
           of the packet to the "m=" line associated with that SSRC.</t>
-		
-	  <t>If the packet is an FIR (PT=PSFB, FMT=4) as defined in
-          <xref target="RFC5104" />, or an LRR (PT=PSFB, FMT=TBD) as
+
+          <t>If the packet is an FIR (PT=PSFB, FMT=4), as defined in
+          <xref target="RFC5104" />, or an LRR (PT=PSFB, FMT=TBD), as
           defined in <xref target="I-D.ietf-avtext-lrr" />, for each
           FCI entry where the SSRC is found in the outgoing SSRC table,
           deliver a copy of the RTCP packet to the "m=" line associated
           with that SSRC.</t>
-		
-          <t>If the packet is of type RTPFB or type PSFB defined in
-          <xref target="RFC4585" /> (but not an FIR or LRR) and the media
+
+          <t>If the packet is of type RTPFB or type PSFB, as defined in
+          <xref target="RFC4585" />, but not previously handled, and the media
           source SSRC for the packet is found in the outgoing SSRC table,
           deliver the packet to the "m=" line associated with that SSRC.</t>
-		
-	  <t>If the packet is of type APP, deliver a copy of the packet to
+
+          <t>If the packet is of type APP, deliver a copy of the packet to
           each "m=" line.</t>
         </list>
       </t>


### PR DESCRIPTION
Remove tabs, capitalization, punctuation