### PR TITLE
Rewrite the text around a=rtcp-mux-only. Fixes #502

### DIFF
--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -1067,7 +1067,7 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             non-multiplexing endpoints.</t>
             <t hangText="require:">The JSEP implementation will only gather RTP
             candidates and will insert an "a=rtcp-mux-only" indication into
-            any offers or answers it generates.
+            any offers it generates.
             This halves the number of candidates that the
             offerer needs to gather. Applying a description with an
             m= section that does not contain an "a=rtcp-mux" attribute
@@ -2185,8 +2185,8 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
               5.1.3. </t>
 
               <t>If the RTP/RTCP multiplexing policy is "require",
-              then an "a=rtcp-mux-only" line, as specified in
-              <xref target="I-D.ietf-mmusic-mux-exclusive" />.</t>
+              an "a=rtcp-mux-only" line, as specified in
+              <xref target="I-D.ietf-mmusic-mux-exclusive" />, Section 4.</t>
 
               <t>An "a=rtcp-rsize" line, as specified in
               <xref target="RFC5506"></xref>, Section 5.</t>
@@ -2443,8 +2443,8 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             the most recent answer.</t>
 
             <t>If the RTP/RTCP multiplexing policy is "require",
-            then an "a=rtcp-mux-only" line, as specified in
-            <xref target="I-D.ietf-mmusic-mux-exclusive" />.</t>
+            an "a=rtcp-mux-only" line, as specified in
+            <xref target="I-D.ietf-mmusic-mux-exclusive" />, Section 4.</t>
 
             <t>The "a=rtcp-rsize" line MUST only be added if present in
             the most recent answer.</t>
@@ -3353,7 +3353,11 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             "ice-lite" attribute MUST NOT be specified.</t>
 
             <t>If the RTP/RTCP multiplexing policy is "require", each m=
-            section MUST contain an "a=rtcp-mux" attribute.</t>
+            section MUST contain an "a=rtcp-mux" attribute. If an
+            "m=" section contains the "a=rtcp-mux-only" attribute
+            then that section MUST also contain an "a=rtcp-mux"
+            attribute.
+            </t>
           </list></t>
 
           <t>If this session description is of type "pranswer" or

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -1066,7 +1066,9 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             allowing for compatibility with either multiplexing or
             non-multiplexing endpoints.</t>
             <t hangText="require:">The JSEP implementation will only gather RTP
-            candidates. This halves the number of candidates that the
+            candidates and will insert an "a=rtcp-mux-only" indication into
+            any offers or answers it generates.
+            This halves the number of candidates that the
             offerer needs to gather. Applying a description with an
             m= section that does not contain an "a=rtcp-mux" attribute
             will cause an error to be returned.</t>
@@ -2182,6 +2184,10 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
               target="RFC5761"></xref>, Section
               5.1.3. </t>
 
+              <t>If the RTP/RTCP multiplexing policy is "require",
+              then an "a=rtcp-mux-only" line, as specified in
+              <xref target="I-D.ietf-mmusic-mux-exclusive" />.</t>
+
               <t>An "a=rtcp-rsize" line, as specified in
               <xref target="RFC5506"></xref>, Section 5.</t>
             </list>
@@ -2436,8 +2442,9 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             <t>The "a=rtcp-mux" line MUST only be added if present in
             the most recent answer.</t>
 
-            <t>The "a=rtcp-mux-only" line MUST only be added if present
-            in the most recent answer.</t>
+            <t>If the RTP/RTCP multiplexing policy is "require",
+            then an "a=rtcp-mux-only" line, as specified in
+            <xref target="I-D.ietf-mmusic-mux-exclusive" />.</t>
 
             <t>The "a=rtcp-rsize" line MUST only be added if present in
             the most recent answer.</t>

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -2442,10 +2442,6 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             <t>The "a=rtcp-mux" line MUST only be added if present in
             the most recent answer.</t>
 
-            <t>If the RTP/RTCP multiplexing policy is "require",
-            an "a=rtcp-mux-only" line, as specified in
-            <xref target="I-D.ietf-mmusic-mux-exclusive" />, Section 4.</t>
-
             <t>The "a=rtcp-rsize" line MUST only be added if present in
             the most recent answer.</t>
           </list></t>
@@ -3354,7 +3350,7 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
 
             <t>If the RTP/RTCP multiplexing policy is "require", each m=
             section MUST contain an "a=rtcp-mux" attribute. If an
-            "m=" section contains the "a=rtcp-mux-only" attribute
+            "m=" section contains an "a=rtcp-mux-only" attribute
             then that section MUST also contain an "a=rtcp-mux"
             attribute.
             </t>


### PR DESCRIPTION
I applied the following principles, which unfortunately are somewhat
inconsistent with the current mux-exclusive draft.

- You use a=rtcp-mux to negotiate mux
- a=rtcp-mux-only is used by the offerer to say "I really mean it"

To that end, offers contain a=rtcp-mux-only if the policy is require.
Answers don't contain it because you don't need it to negotiate mux.