### PR TITLE
Fix inconsistencies in example descriptions

### DIFF
--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -3865,7 +3865,7 @@ WebServer->BobJS:   signaling with |offer-A1|
 //                  |offer-A1| arrives at Bob
 BobJS->BobUA:       create a PeerConnection
 BobJS->BobUA:       setRemoteDescription with |offer-A1|
-BobUA->BobJS:       onaddstream event with remoteStream
+BobUA->BobJS:       ontrack events for audio and video tracks
 
 //                  Bob accepts call
 BobJS->BobUA:       addTrack with local tracks
@@ -3883,7 +3883,7 @@ WebServer->AliceJS: signaling with |answer-A1|
 
 //                  |answer-A1| arrives at Alice
 AliceJS->AliceUA:   setRemoteDescription with |answer-A1|
-AliceUA->AliceJS:   onaddstream event with remoteStream
+AliceUA->AliceJS:   ontrack events for audio and video tracks
 
 //                  media flows
 BobUA->AliceUA:     media sent from Bob to Alice
@@ -4054,18 +4054,22 @@ WebServer->BobJS:   signaling with |offer-B1|
 //                  |offer-B1| arrives at Bob
 BobJS->BobUA:       create a PeerConnection
 BobJS->BobUA:       setRemoteDescription with |offer-B1|
-BobUA->BobJS:       onaddstream with audio track from Alice
+BobUA->BobJS:       ontrack with audio track from Alice
 
 //                  candidates are sent to Bob
-AliceUA->AliceJS:   onicecandidate event with |candidate-B1| (host)
-AliceJS->WebServer: signaling with |candidate-B1|
-AliceUA->AliceJS:   onicecandidate event with |candidate-B2| (srflx)
-AliceJS->WebServer: signaling with |candidate-B2|
+AliceUA->AliceJS:   onicecandidate event with |offer-B1-candidate-1| (host)
+AliceJS->WebServer: signaling with |offer-B1-candidate-1|
+AliceUA->AliceJS:   onicecandidate event with |offer-B1-candidate-2| (srflx)
+AliceJS->WebServer: signaling with |offer-B1-candidate-2|
+AliceUA->AliceJS:   onicecandidate event with |offer-B1-candidate-3| (relay)
+AliceJS->WebServer: signaling with |offer-B1-candidate-3|
 
-WebServer->BobJS:   signaling with |candidate-B1|
-BobJS->BobUA:       addIceCandidate with |candidate-B1|
-WebServer->BobJS:   signaling with |candidate-B2|
-BobJS->BobUA:       addIceCandidate with |candidate-B2|
+WebServer->BobJS:   signaling with |offer-B1-candidate-1|
+BobJS->BobUA:       addIceCandidate with |offer-B1-candidate-1|
+WebServer->BobJS:   signaling with |offer-B1-candidate-2|
+BobJS->BobUA:       addIceCandidate with |offer-B1-candidate-2|
+WebServer->BobJS:   signaling with |offer-B1-candidate-3|
+BobJS->BobUA:       addIceCandidate with |offer-B1-candidate-3|
 
 //                  Bob accepts call
 BobJS->BobUA:       addTrack with local audio
@@ -4077,18 +4081,22 @@ BobJS->BobUA:       setLocalDescription with |answer-B1|
 BobJS->WebServer:   signaling with |answer-B1|
 WebServer->AliceJS: signaling with |answer-B1|
 AliceJS->AliceUA:   setRemoteDescription with |answer-B1|
-AliceUA->AliceJS:   onaddstream event with audio track from Bob
+AliceUA->AliceJS:   ontrack event with audio track from Bob
 
 //                  candidates are sent to Alice
-BobUA->BobJS:       onicecandidate event with |candidate-B3| (host)
-BobJS->WebServer:   signaling with |candidate-B3|
-BobUA->BobJS:       onicecandidate event with |candidate-B4| (srflx)
-BobJS->WebServer:   signaling with |candidate-B4|
+BobUA->BobJS:       onicecandidate event with |answer-B1-candidate-1| (host)
+BobJS->WebServer:   signaling with |answer-B1-candidate-1|
+BobUA->BobJS:       onicecandidate event with |answer-B1-candidate-2| (srflx)
+BobJS->WebServer:   signaling with |answer-B1-candidate-2|
+BobUA->BobJS:       onicecandidate event with |answer-B1-candidate-3| (relay)
+BobJS->WebServer:   signaling with |answer-B1-candidate-3|
 
-WebServer->AliceJS: signaling with |candidate-B3|
-AliceJS->AliceUA:   addIceCandidate with |candidate-B3|
-WebServer->AliceJS: signaling with |candidate-B4|
-AliceJS->AliceUA:   addIceCandidate with |candidate-B4|
+WebServer->AliceJS: signaling with |answer-B1-candidate-1|
+AliceJS->AliceUA:   addIceCandidate with |answer-B1-candidate-1|
+WebServer->AliceJS: signaling with |answer-B1-candidate-2|
+AliceJS->AliceUA:   addIceCandidate with |answer-B1-candidate-2|
+WebServer->AliceJS: signaling with |answer-B1-candidate-3|
+AliceJS->AliceUA:   addIceCandidate with |answer-B1-candidate-3|
 
 //                  data channel opens
 BobUA->BobJS:       ondatachannel event
@@ -4111,8 +4119,8 @@ BobJS->BobUA:       setLocalDescription with |offer-B2|
 BobJS->WebServer:   signaling with |offer-B2|
 WebServer->AliceJS: signaling with |offer-B2|
 AliceJS->AliceUA:   setRemoteDescription with |offer-B2|
-AliceUA->AliceJS:   onaddstream event with first video stream
-AliceUA->AliceJS:   onaddstream event with second video stream
+AliceUA->AliceJS:   ontrack event with first video track
+AliceUA->AliceJS:   ontrack event with second video track
 AliceJS->AliceUA:   createAnswer to get |answer-B2|
 AliceJS->AliceUA:   setLocalDescription with |answer-B2|
 
@@ -4486,13 +4494,8 @@ a=msid:- 8dfffea7-c7d6-4036-86bd-98c59391f8a3
 //                  set up local media state
 AliceJS->AliceUA:   create new PeerConnection
 AliceJS->AliceUA:   addTrack with two tracks: audio and video
-AliceJS->AliceUA:   createOffer to get offer
-AliceJS->AliceUA:   setLocalDescription with offer
-AliceUA->AliceJS:   multiple onicecandidate events with candidates
-
-//                  wait for ICE gathering to complete
-AliceUA->AliceJS:   onicecandidate event with null candidate
-AliceJS->AliceUA:   get |offer-C1| from value of localDescription
+AliceJS->AliceUA:   createOffer to get |offer-C1|
+AliceJS->AliceUA:   setLocalDescription with |offer-C1|
 
 //                  |offer-C1| is sent over signaling protocol to Bob
 AliceJS->WebServer: signaling with |offer-C1|
@@ -4501,18 +4504,20 @@ WebServer->BobJS:   signaling with |offer-C1|
 //                  |offer-C1| arrives at Bob
 BobJS->BobUA:       create a PeerConnection
 BobJS->BobUA:       setRemoteDescription with |offer-C1|
-BobUA->BobJS:       onaddtrack events for audio and video
+BobUA->BobJS:       ontrack events for audio and video
+
+//                  candidates are sent to Bob
+AliceUA->AliceJS:   onicecandidate event with |offer-C1-candidate-1| (relay)
+AliceJS->WebServer: signaling with |offer-C1-candidate-1|
+
+WebServer->BobJS:   signaling with |offer-C1-candidate-1|
+BobJS->BobUA:       addIceCandidate with |offer-C1-candidate-1|
 
 //                  Bob prepares an early answer to warm up the transport
 BobJS->BobUA:       addTransceiver with null audio and video tracks
 BobJS->BobUA:       transceiver.setDirection(sendonly) for both transceivers
 BobJS->BobUA:       createAnswer
 BobJS->BobUA:       setLocalDescription with answer
-BobUA->BobJS:       multiple onicecandidate events with candidates
-
-//                  wait for ICE gathering to complete
-BobUA->BobJS:       onicecandidate event with null candidate
-BobJS->BobUA:       get |answer-C1| from value of localDescription
 
 //                  |answer-C1| is sent over signaling protocol to Alice
 BobJS->WebServer:   signaling with |answer-C1|
@@ -4520,7 +4525,14 @@ WebServer->AliceJS: signaling with |answer-C1|
 
 //                  |answer-C1| (sendonly) arrives at Alice
 AliceJS->AliceUA:   setRemoteDescription with |answer-C1|
-AliceUA->AliceJS:   onaddtrack events for audio and video
+AliceUA->AliceJS:   ontrack events for audio and video
+
+//                  candidates are sent to Alice
+BobUA->BobJS:       onicecandidate event with |answer-B1-candidate-1| (relay)
+BobJS->WebServer:   signaling with |answer-B1-candidate-1|
+
+WebServer->AliceJS: signaling with |answer-B1-candidate-1|
+AliceJS->AliceUA:   addIceCandidate with |answer-B1-candidate-1|
 
 //                  ICE and DTLS establish while call is ringing
 


### PR DESCRIPTION
Fixes #535
- onaddstream -> ontrack
- Complex example has 3 candidates for each side
- Warmup example uses trickle ICE