### PR TITLE
Note that sometimes data m= sections may contain media appropriate

### DIFF
--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -2378,6 +2378,13 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             for bundled m= sections, as
             described in <xref target="I-D.ietf-mmusic-sdp-bundle-negotiation"/>,
             Section 8.1.
+            Note that if media m= sections are bundled into a
+            data m= section, then the TRANSPORT and IDENTICAL attributes
+            may appear in the data m= section even if they would otherwise
+            only be appropriate for a media m= section (e.g., "a=rtcp-mux").
+            This cannot happen in initial offers because all BUNDLE policies
+            result in at least one m= section without "a=bundle-only" on
+            such offers.
           </t>
           </list></t>
 
@@ -2822,7 +2829,10 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
           section MUST also be generated for data. The &lt;media&gt;
           field MUST be set to "application" and the &lt;proto&gt; and
           "fmt" fields MUST be set to exactly match the fields in the
-          offer.</t>
+          offer. Note that if media m= sections are bundled into a
+          data m= section, then the TRANSPORT and IDENTICAL attributes
+          may appear in the data m= section even if they would otherwise
+          only be appropriate for a media m= section (e.g., "a=rtcp-mux").</t>
 
           <t>Within the data m= section, an "a=mid" line MUST be
           generated and included as described above,

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -2378,13 +2378,18 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             for bundled m= sections, as
             described in <xref target="I-D.ietf-mmusic-sdp-bundle-negotiation"/>,
             Section 8.1.
+            </t>
+            <t>
             Note that if media m= sections are bundled into a
-            data m= section, then the TRANSPORT and IDENTICAL attributes
+            data m= section, then certain TRANSPORT and IDENTICAL attributes
             may appear in the data m= section even if they would otherwise
             only be appropriate for a media m= section (e.g., "a=rtcp-mux").
-            This cannot happen in initial offers because all BUNDLE policies
-            result in at least one m= section without "a=bundle-only" on
-            such offers.
+            This cannot happen in initial offers because in the initial
+            offer JSEP implementations always list media m= sections (if any)
+            before the data m= section (if any), and at least one of those
+            media m= sections will not have the "a=bundle-only" attribute.
+            Therefore, in initial offers, any "a=bundle-only" m= sections
+            will be bundled into a preceding non-bundle-only media m= section.
           </t>
           </list></t>
 
@@ -2830,7 +2835,7 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
           field MUST be set to "application" and the &lt;proto&gt; and
           "fmt" fields MUST be set to exactly match the fields in the
           offer. Note that if media m= sections are bundled into a
-          data m= section, then the TRANSPORT and IDENTICAL attributes
+          data m= section, then certain TRANSPORT and IDENTICAL attributes
           may appear in the data m= section even if they would otherwise
           only be appropriate for a media m= section (e.g., "a=rtcp-mux").</t>
 


### PR DESCRIPTION
attributes. As far as I can tell this can happen:

- On re-offers
- On any answer because nothing requires the offerer to generate
  bundle tags in the same order as m= lines (even though the
  data channel m= line is last)

See: https://github.com/cdh4u/draft-sdp-bundle/issues/27