### PR TITLE
remove a=ssrc-group requirements from media level parsing

### DIFF
--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -3368,7 +3368,7 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             stored.</t>
             
             <t>Any "a=ssrc" attributes MUST be parsed
-            as specified in <xref target="RFC5576" />, Sections 4.1,
+            as specified in <xref target="RFC5576" />, Section 4.1,
             and their values stored.</t>
 
             <t>Any "a=extmap" attributes MUST be parsed as specified in

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -3367,11 +3367,6 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             <xref target="RFC4566" />, Section 6, and its value
             stored.</t>
 
-            <t>Any "a=ssrc" or "a=ssrc-group" attributes MUST be parsed
-            as specified in
-            <xref target="RFC5576" />, Sections 4.1-4.2, and their
-            values stored.</t>
-
             <t>Any "a=extmap" attributes MUST be parsed as specified in
 
             <xref target="RFC5285" />, Section 5, and their values

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -3366,6 +3366,10 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             "a=sendrecv") MUST be parsed as described in
             <xref target="RFC4566" />, Section 6, and its value
             stored.</t>
+            
+            <t>Any "a=ssrc" attributes MUST be parsed
+            as specified in <xref target="RFC5576" />, Sections 4.1,
+            and their values stored.</t>
 
             <t>Any "a=extmap" attributes MUST be parsed as specified in
 


### PR DESCRIPTION
removes parsing of a=ssrc and a=ssrc-group. The createOffer parts were removed in the -17 draft.