### PR TITLE
Clarify that when generating an answer the proto field value

### DIFF
--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -1784,8 +1784,9 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
           <t>
             <list style="symbols">
 
-              <t>The profile in any "m=" line in any answer MUST
-              exactly match the profile provided in the offer.</t>
+              <t>The profile in any "m=" line in any answer generated 
+			  by the JSEP implementation MUST exactly match the 
+			  profile provided in the offer.</t>
 
               <t>Any profile matching the following patterns MUST be
               accepted: "RTP/[S]AVP[F]" and

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -1779,19 +1779,18 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
           "(UDP,TCP)/TLS/RTP/SAVPF". In order to simplify compatibility
           with such endpoints, JSEP implementations MUST follow the
           following rules when processing the media m= sections in an
-          offer:</t>
+          received offer:</t>
 
           <t>
             <list style="symbols">
 
+              <t>Any profile in the offer matching the following patterns
+			  MUST be accepted: "RTP/[S]AVP[F]" and 
+			  "(UDP/TCP)/TLS/RTP/SAVP[F]".</t>
+
               <t>The profile in any "m=" line in any answer generated 
-			  by the JSEP implementation MUST exactly match the 
-			  profile provided in the offer.</t>
-
-              <t>Any profile matching the following patterns MUST be
-              accepted: "RTP/[S]AVP[F]" and
-              "(UDP/TCP)/TLS/RTP/SAVP[F]"</t>
-
+			  MUST exactly match the profile provided in the offer.</t>
+			  
               <t>Because DTLS-SRTP is REQUIRED, the choice of SAVP or
               AVP has no effect; support for DTLS-SRTP is determined by
               the presence of one or more "a=fingerprint" attribute.

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -1785,7 +1785,7 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             <list style="symbols">
               <t>Any profile in the offer matching the following patterns
               MUST be accepted: "RTP/[S]AVP[F]" and 
-              "(UDP/TCP)/TLS/RTP/SAVP[F]".
+              "(UDP|TCP)/TLS/RTP/SAVP[F]".
               </t>
 
               <t>The profile in any "m=" line in any generated answer

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -1778,18 +1778,19 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
           "a=rtcp-fb" attributes, indicating its willingness to support
           "(UDP,TCP)/TLS/RTP/SAVPF". In order to simplify compatibility
           with such endpoints, JSEP implementations MUST follow the
-          following rules when processing the media m= sections in an
+          following rules when processing the media m= sections in a
           received offer:</t>
 
           <t>
             <list style="symbols">
-
               <t>Any profile in the offer matching the following patterns
-			  MUST be accepted: "RTP/[S]AVP[F]" and 
-			  "(UDP/TCP)/TLS/RTP/SAVP[F]".</t>
+              MUST be accepted: "RTP/[S]AVP[F]" and 
+              "(UDP/TCP)/TLS/RTP/SAVP[F]".
+              </t>
 
-              <t>The profile in any "m=" line in any answer generated 
-			  MUST exactly match the profile provided in the offer.</t>
+              <t>The profile in any "m=" line in any generated answer
+              MUST exactly match the profile provided in the offer.
+              </t>
 			  
               <t>Because DTLS-SRTP is REQUIRED, the choice of SAVP or
               AVP has no effect; support for DTLS-SRTP is determined by


### PR DESCRIPTION
Proposal for how to clarify that when JSEP implementation generates an answer it needs to have the proto value identical to what is in the offer. 