### PR TITLE
Clarify o= and s= are only useless in JSEP as opposed to generally us…

### DIFF
--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -1858,7 +1858,7 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             name, e.g. "s=-". Note that this differs from the advice in
 
             <xref target="RFC4566" /> which proposes a single space, but
-            as both "o=" and "s=" are meaningless, having the same
+            as both "o=" and "s=" are meaningless in JSEP, having the same
             meaningless value seems clearer.</t>
 
             <t>Session Information ("i="), URI ("u="), Email Address


### PR DESCRIPTION
…eless. Fixes #653