### PR TITLE
Add redundant clarifying text to address review comment. Fixes #672

### DIFF
--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -3729,7 +3729,12 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             primary payload type, as described in
             <xref target="RFC4588" />, Section 4. If any referenced
             primary payload types are not present, this MUST result in
-            an error.</t>
+            an error. Note that RTX payload types may
+            refer to primary payload types which are not supported
+            by the local media implementation
+            in which case, the RTX payload type MUST also be
+            ignored.
+            </t>
 
             <t>For each specified fmtp parameter that is supported by
             the local implementation, enable them on the associated

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -3731,7 +3731,7 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             primary payload types are not present, this MUST result in
             an error. Note that RTX payload types may
             refer to primary payload types which are not supported
-            by the local media implementation
+            by the local media implementation,
             in which case, the RTX payload type MUST also be
             ignored.
             </t>


### PR DESCRIPTION
Fixes #672 