### PR TITLE
Clarify normative language for scaling

### DIFF
--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -747,19 +747,20 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
           to a RtpSender, which is encoding the track video
           at the same or lower resolution(s) (the "encoder resolutions"),
           and a remote description is applied that references the sender and
-          contains valid "a=imageattr recv" attributes, it will
+          contains valid "a=imageattr recv" attributes, it MUST
           follow the rules below to ensure the sender does not transmit a
           resolution that would exceed the size criteria specified in the
-          attributes. These rules are followed
+          attributes. These rules MUST be followed
           as long as the attributes remain present in the remote description,
-          including if the track changes its resolution,
-          or if the track is replaced with a different track.
+          including cases in which the track changes its resolution,
+          or is replaced with a different track.
           </t>
 
           <t>Depending on how the RtpSender is configured, it may be producing
-          a single resolution, or, if simulcast <xref target="sec.simulcast" />
-          has been negotiated, multiple specific resolutions. In addition,
-          depending on the configuration, each encoding may have the
+          a single encoding at a certain resolution, or, if
+          simulcast <xref target="sec.simulcast" /> has been negotiated,
+          multiple encodings, each at their own specific resolution. In
+          addition, depending on the configuration, each encoding may have the
           flexibility to reduce resolution when needed, or may be locked to
           a specific output resolution.
           </t>
@@ -768,20 +769,21 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
           rules are applied to determine what should be transmitted:
             <list style="symbols">
               <t>First, the right "a=imageattr recv" attribute is selected.
-              While JSEP endpoints will not include more than one such
-              attribute per media format, non-JSEP endpoints may send
-              multiple relevant "a=imageattr recv" attributes in a m=
-              section. The correct attribute is selected by taking the
+              This is performed by taking the
               attribute with the highest "q=" value from the set of attributes
               that reference the media format that has been selected for the
               specified encoding. If multiple attributes have the same "q="
               value, the one that appears first in the m= section is used.
+              Note that while JSEP endpoints will include at most
+              one "a=imageattr recv" attribute per media format, JSEP
+              endpoints may receive session descriptions from non-JSEP
+              endpoints with m= sections that contain multiple such attributes.
               </t>
 
               <t>If there is an applicable "a=imageattr recv" attribute for
               the encoding, the limits from the attribute are then compared to
               the encoder resolution. Only the specific limits mentioned below
-              are considered; any other values, e.g. picture aspect ratio,
+              are considered; any other values, such as picture aspect ratio,
               MUST be ignored.
               Note that when considering a MediaStreamTrack that is producing
               rotated video, the unrotated resolution MUST be used for the

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -768,8 +768,8 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
           <t>For each encoding being produced by the RtpSender, the following
           rules are applied to determine what should be transmitted:
             <list style="symbols">
-              <t>First, the right "a=imageattr recv" attribute is selected.
-              This is performed by taking the
+              <t>First, the most suitable "a=imageattr recv" attribute is
+              selected. This is performed by taking the
               attribute with the highest "q=" value from the set of attributes
               that reference the media format that has been selected for the
               specified encoding. If multiple attributes have the same "q="
@@ -801,7 +801,10 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
               <t>If the encoder resolution exceeds the maximum size permitted by the
               attribute, and the encoder is allowed to adjust its resolution,
               the encoder SHOULD apply downscaling in order to satisfy the limits,
-              although the downscaling MUST NOT change the track aspect ratio.
+              although the downscaling MUST NOT change the picture aspect ratio
+              of the encoding. For example, if the encoder resolution is
+              1280x720, and the attribute specified a maximum of 640x480, the
+              expected output resolution would be 640x360.
               If downscaling cannot be applied, the encoding MUST NOT be
               transmitted, and an error SHOULD be surfaced to the application.</t>
 

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -744,11 +744,12 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
           <t>This specification prescribes more specific behavior. When
           a sender of a given MediaStreamTrack, which is producing
           video of a certain resolution, receives an "a=imageattr recv"
-          attribute, it MUST check to see if the original resolution
-          meets the size criteria specified in the attribute, and adapt
-          the resolution accordingly by scaling (if appropriate). Note
-          that when considering a MediaStreamTrack that is producing
-          rotated video, the unrotated resolution MUST be used. This is
+          attribute, it will follow the rules below to check if the original
+          resolution meets the size criteria specified in the attribute,
+          and, if appropriate, adjust the resolution.
+          Note that when considering a MediaStreamTrack that is producing
+          rotated video, the unrotated resolution MUST be used for the
+          checks. This is
           required regardless of whether the receiver supports
           performing receive-side rotation (e.g., through CVO
           <xref target="TS26.114" />), as it significantly simplifies
@@ -779,15 +780,13 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
           Downscaling MUST NOT change the track aspect ratio.</t>
 
           <t>If the original resolution is less than the size limits in
-          the attribute, upscaling is needed, but this may not be
-          appropriate in all cases. To address this concern, the
+          the attribute, upscaling is needed, but this may not always be
+          appropriate. To address this concern, the
           application can set an upscaling policy for each sent track.
-          For this case, if upscaling is permitted by policy, the
+          If upscaling is permitted by policy, the
           sender SHOULD apply upscaling in order to provide the desired
           resolution. Otherwise, the sender MUST NOT apply upscaling.
-          The sender SHOULD NOT upscale in other cases, even if the
-          policy permits it. Upscaling MUST NOT change the track aspect
-          ratio.</t>
+          Upscaling MUST NOT change the track aspect ratio.</t>
 
           <t>If there is no appropriate and permitted scaling mechanism
           that allows the received size limits to be satisfied, the

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -741,65 +741,80 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
           constrain the video formats that the sender can use, but
           gives an indication of the preferred values.</t>
 
-          <t>This specification prescribes more specific behavior. When
-          a sender of a given MediaStreamTrack, which is producing
-          video of a certain resolution, receives an "a=imageattr recv"
-          attribute, it will follow the rules below to check if the original
-          resolution meets the size criteria specified in the attribute,
-          and, if appropriate, adjust the resolution.
-          Note that when considering a MediaStreamTrack that is producing
-          rotated video, the unrotated resolution MUST be used for the
-          checks. This is
-          required regardless of whether the receiver supports
-          performing receive-side rotation (e.g., through CVO
-          <xref target="TS26.114" />), as it significantly simplifies
-          the matching logic.</t>
+          <t>This specification prescribes more specific behavior.
+          When a MediaStreamTrack, which is producing
+          video of a certain resolution (the "track resolution"), is attached
+          to a RtpSender, which is encoding the track video
+          at the same or lower resolution(s) (the "encoder resolutions"),
+          and a remote description is applied that references the sender and
+          contains valid "a=imageattr recv" attributes, it will
+          follow the rules below to ensure the sender does not transmit a
+          resolution that would exceed the size criteria specified in the
+          attributes. These rules are followed
+          as long as the attributes remain present in the remote description,
+          including if the track changes its resolution,
+          or if the track is replaced with a different track.
+          </t>
 
-          <t>For the purposes of resolution negotiation, only size
-          limits are considered. Any other values, e.g. picture or
-          sample aspect ratio, MUST be ignored.</t>
+          <t>Depending on how the RtpSender is configured, it may be producing
+          a single resolution, or, if simulcast <xref target="sec.simulcast" />
+          has been negotiated, multiple specific resolutions. In addition,
+          depending on the configuration, each encoding may have the
+          flexibility to reduce resolution when needed, or may be locked to
+          a specific output resolution.
+          </t>
 
-          <t>When communicating with a non-JSEP endpoint, multiple
-          relevant "a=imageattr recv" attributes may be present in a
-          received m= section. If this occurs, attributes other than
-          the one with the highest "q=" value MUST be ignored. If
-          multiple attributes have the same "q=" value, those that
-          appear after the first such attribute in the m= section MUST
-          be ignored.</t>
+          <t>For each encoding being produced by the RtpSender, the following
+          rules are applied to determine what should be transmitted:
+            <list type="symbols">
+              <t>First, the right "a=imageattr recv" attribute is selected.
+              While JSEP endpoints will not include more than one such
+              attribute per media format, non-JSEP endpoints may send
+              multiple relevant "a=imageattr recv" attributes in a m=
+              section. The correct attribute is selected by taking the
+              attribute with the highest "q=" value from the set of attributes
+              that reference the media format that has been selected for the
+              specified encoding. If multiple attributes have the same "q="
+              value, the one that appears first in the m= section is used.
+              </t>
 
-          <t>If an "a=imageattr recv" attribute references a different
-          video payload type than what has been selected for sending
-          the MediaStreamTrack, it MUST be ignored.</t>
+              <t>If there is an applicable "a=imageattr recv" attribute for
+              the encoding, the limits from the attribute are then compared to
+              the encoder resolution. Only the specific limits mentioned below
+              are considered; any other values, e.g. picture aspect ratio,
+              MUST be ignored.
+              Note that when considering a MediaStreamTrack that is producing
+              rotated video, the unrotated resolution MUST be used for the
+              checks. This is
+              required regardless of whether the receiver supports
+              performing receive-side rotation (e.g., through CVO
+              <xref target="TS26.114" />), as it significantly simplifies
+              the matching logic.</t>
 
-          <t>If the original resolution matches the size limits in the
-          attribute, the track MUST be transmitted untouched.</t>
+              <t>If the attribute includes a "sar=" (sample aspect ratio)
+              value set to something other than "1.0", indicating the
+              receiver wants to receive non-square pixels, this cannot be
+              satisfied and the sender MUST NOT transmit the encoding.</t>
 
-          <t>If the original resolution exceeds the size limits in the
-          attribute, the sender SHOULD apply downscaling to the output
-          of the MediaStreamTrack in order to satisfy the limits.
-          Downscaling MUST NOT change the track aspect ratio.</t>
+              <t>If the encoder resolution exceeds the maximum size permitted by the
+              attribute, and the encoder is allowed to adjust its resolution,
+              the encoder SHOULD apply downscaling in order to satisfy the limits,
+              although the downscaling MUST NOT change the track aspect ratio.
+              If downscaling cannot be applied, the encoding MUST NOT be
+              transmitted, and an error SHOULD be surfaced to the application.</t>
 
-          <t>If the original resolution is less than the size limits in
-          the attribute, upscaling is needed, but this may not always be
-          appropriate. To address this concern, the
-          application can set an upscaling policy for each sent track.
-          If upscaling is permitted by policy, the
-          sender SHOULD apply upscaling in order to provide the desired
-          resolution. Otherwise, the sender MUST NOT apply upscaling.
-          Upscaling MUST NOT change the track aspect ratio.</t>
+              <t>If the encoder resolution is less than the minimum size permitted
+              by the attribute, the encoding MUST NOT be transmitted, and an
+              error SHOULD be surfaced to the application; the encoder
+              MUST NOT apply upscaling. JSEP implementations SHOULD avoid this
+              situation by allowing receipt of arbitrarily small resolutions,
+              perhaps via fallback to a software decoder.</t>
 
-          <t>If there is no appropriate and permitted scaling mechanism
-          that allows the received size limits to be satisfied, the
-          sender MUST NOT transmit the track.</t>
-
-          <t>If the attribute includes a "sar=" (sample aspect ratio)
-          value set to something other than "1.0", indicating the
-          receiver wants to receive non-square pixels, this cannot be
-          satisfied and the sender MUST NOT transmit the track.</t>
-
-          <t>In the special case of receiving a maximum resolution of
-          [0, 0], as described above, the sender MUST NOT transmit the
-          track.</t>
+              <t>In the special case of a maximum resolution of
+              [0, 0], as described above, the sender MUST NOT transmit the
+              encoding.</t>
+            </list>
+          </t>
         </section>
       </section>
       <section title="Simulcast" anchor="sec.simulcast">

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -766,7 +766,7 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
 
           <t>For each encoding being produced by the RtpSender, the following
           rules are applied to determine what should be transmitted:
-            <list type="symbols">
+            <list style="symbols">
               <t>First, the right "a=imageattr recv" attribute is selected.
               While JSEP endpoints will not include more than one such
               attribute per media format, non-JSEP endpoints may send


### PR DESCRIPTION
Fixes #741
Fixes #715
Fixes #648
Fixes #647

- Specifically consider simulcast
- Remove upscaling
- Clean up some contradictory text