### PR TITLE
Fixes #730. Remove the requirement that fingerprints match the

### DIFF
--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -2117,7 +2117,7 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
               <xref target="RFC5245"></xref>, Section 15.4.</t>
 
               <t>For each desired digest algorithm, one or more
-              "a=fingerprint" line for each of the endpoint's
+              "a=fingerprint" lines for each of the endpoint's
               certificates, as specified in
               <xref target="RFC8122"></xref>, Section 5.</t>
 
@@ -2844,7 +2844,8 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
               <t>"a=ice-ufrag" and "a=ice-pwd" lines, as specified in
               <xref target="RFC5245"></xref>, Section 15.4.</t>
 
-              <t>An "a=fingerprint" line for each of the endpoint's
+              <t>For each desired digest algorithm, one or more
+              "a=fingerprint" lines for each of the endpoint's
               certificates, as specified in
               <xref target="RFC8122"></xref>, Section 5.</t>
 

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -2118,9 +2118,7 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
 
               <t>An "a=fingerprint" line for each of the endpoint's
               certificates, as specified in
-              <xref target="RFC8122"></xref>, Section 5; the digest
-              algorithm used for the fingerprint MUST match that used
-              in the certificate signature.</t>
+              <xref target="RFC8122"></xref>, Section 5.</t>
 
               <t>An "a=setup" line, as specified in
               <xref target="RFC4145"></xref>, Section 4, and clarified
@@ -2847,9 +2845,7 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
 
               <t>An "a=fingerprint" line for each of the endpoint's
               certificates, as specified in
-              <xref target="RFC8122"></xref>, Section 5; the digest
-              algorithm used for the fingerprint MUST match that used
-              in the certificate signature.</t>
+              <xref target="RFC8122"></xref>, Section 5.</t>
 
               <t>An "a=setup" line, as specified in
               <xref target="RFC4145"></xref>, Section 4, and clarified
@@ -5303,7 +5299,7 @@ a=msid:bbce3ba6-abfc-ac63-d00a-e15b286f8fce
           <date year="2014" month="December" />
         </front>
       </reference>
-      
+
     </references>
     <section title="Appendix A" anchor="sec.appendix-a">
 

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -2116,7 +2116,8 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
               <t>"a=ice-ufrag" and "a=ice-pwd" lines, as specified in
               <xref target="RFC5245"></xref>, Section 15.4.</t>
 
-              <t>An "a=fingerprint" line for each of the endpoint's
+              <t>For each desired digest algorithm, one or more
+              "a=fingerprint" line for each of the endpoint's
               certificates, as specified in
               <xref target="RFC8122"></xref>, Section 5.</t>
 


### PR DESCRIPTION
certificate.

This was updated in RFC 8122.