### PR TITLE
Remove checks on installing local description. Fixes #669.

### DIFF
--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -3539,7 +3539,7 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             m= section contains an "a=rtcp-mux-only" attribute then
             that section MUST also contain an "a=rtcp-mux"
             attribute.</t>
-            
+
             <t>
             If this m= section was present in the previous
             answer then the state of RTP/RTCP multiplexing MUST
@@ -3588,7 +3588,7 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
           it is an answer and the m= section is bundled into
           into another m= section.)</t>
 
-          <t>Or, if the ICE ufrag and password values have changed, and
+          <t>Or, if the ICE ufrag and password values have changed,
           trigger the ICE agent
           to start an ICE restart, and begin gathering new candidates
           for the m= section as described in
@@ -3621,7 +3621,7 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
 
             <t>For each specified RTP header extension, establish a
             mapping between the extension ID and URI, as described in
-            <xref target="RFC5285" /> Section 6.</t>
+            <xref target="RFC5285" />, Section 6.</t>
 
             <t>If the MID header extension is supported, prepare to
             demux RTP streams intended for this m= section based on the

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -2441,8 +2441,8 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             <t>The "a=rtcp" line MUST NOT be added if the most recent
             answer included an "a=rtcp-mux" line.</t>
 
-            <t>The "a=rtcp-mux" line MUST NOT be added unless present in
-            the most recent answer.</t>
+            <t>The "a=rtcp-mux" line MUST be the same as that in the most
+            recent answer.</t>
 
             <t>The "a=rtcp-mux-only" line MUST NOT be added.</t>
 
@@ -3023,6 +3023,10 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             role value consistent with the existing DTLS association,
             if the association is being continued by the offerer.</t>
 
+            <t>RTCP multiplexing must be used, and an "a=rtcp-mux"
+            line inserted if and only if the m= section previously
+            used RTCP multiplexing.</t>
+
             <t>If the m= section is not bundled into another m= section
             and RTCP multiplexing is not active, an "a=rtcp" attribute
             line MUST be filled in with the port and address of the
@@ -3534,7 +3538,9 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             m= section MUST contain an "a=rtcp-mux" attribute. If an
             "m=" section contains an "a=rtcp-mux-only" attribute then
             that section MUST also contain an "a=rtcp-mux"
-            attribute.</t>
+            attribute. If this m= section was present in the previous
+            answer then the state of RTP/RTCP multiplexing MUST
+            match what was previously negotiated.</t>
           </list></t>
 
           <t>If this session description is of type "pranswer" or
@@ -3573,11 +3579,14 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
 
           <t>If this m= section is new, begin gathering candidates for
           it, as defined in
-          <xref target="RFC5245" />, Section 4.1.1, unless it has been
-          marked as bundle-only.</t>
+          <xref target="RFC5245" />, Section 4.1.1, unless it
+          is definitively being bundled (either this is an
+          offer and the m= section is marked bundle-only or
+          it is an answer and the m= section is bundled into
+          into another m= section</t>
 
           <t>Or, if the ICE ufrag and password values have changed, and
-          it has not been marked as bundle-only, trigger the ICE agent
+          it is not bundled into another m= section, trigger the ICE agent
           to start an ICE restart, and begin gathering new candidates
           for the m= section as described in
           <xref target="RFC5245" />, Section 9.1.1.1. If this
@@ -3605,17 +3614,12 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
 
             <t>If RTCP mux is indicated, prepare to demux RTP and RTCP
             from the RTP ICE component, as specified in
-            <xref target="RFC5761" />, Section 5.1.3. If RTCP mux is
-            not indicated, but was previously negotiated, i.e., the
-            RTCP ICE component no longer exists, this MUST result in an
-            error.</t>
+            <xref target="RFC5761" />, Section 5.1.3.</t>
 
             <t>For each specified RTP header extension, establish a
             mapping between the extension ID and URI, as described in
             section 6 of
-            <xref target="RFC5285" />. If any indicated RTP header
-            extension is not supported, this MUST result in an
-            error.</t>
+            <xref target="RFC5285" />.</t>
 
             <t>If the MID header extension is supported, prepare to
             demux RTP streams intended for this m= section based on the
@@ -3630,16 +3634,12 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             demux RTP streams intended for this m= section based on the
             media formats supported by this m= section, as described in
             <xref target="I-D.ietf-mmusic-sdp-bundle-negotiation" />,
-            Section 10.2.
-            If any indicated media format is not supported, this MUST result
-            in an error.</t>
+            Section 10.2.</t>
 
             <t>For each specified "rtx" media format, establish a
             mapping between the RTX payload type and its associated
             primary payload type, as described in
-            <xref target="RFC4588" />, Sections 8.6 and 8.7. If any
-            referenced primary payload types are not present, this MUST
-            result in an error.</t>
+            <xref target="RFC4588" />, Sections 8.6 and 8.7.</t>
 
             <t>If the directional attribute is of type "sendrecv" or
             "recvonly", enable receipt and decoding of media.</t>

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -3536,9 +3536,12 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
 
             <t>If the RTP/RTCP multiplexing policy is "require", each
             m= section MUST contain an "a=rtcp-mux" attribute. If an
-            "m=" section contains an "a=rtcp-mux-only" attribute then
+            m= section contains an "a=rtcp-mux-only" attribute then
             that section MUST also contain an "a=rtcp-mux"
-            attribute. If this m= section was present in the previous
+            attribute.</t>
+            
+            <t>
+            If this m= section was present in the previous
             answer then the state of RTP/RTCP multiplexing MUST
             match what was previously negotiated.</t>
           </list></t>
@@ -3581,12 +3584,12 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
           it, as defined in
           <xref target="RFC5245" />, Section 4.1.1, unless it
           is definitively being bundled (either this is an
-          offer and the m= section is marked bundle-only or
+          offer and the m= section is marked bundle-only, or
           it is an answer and the m= section is bundled into
-          into another m= section</t>
+          into another m= section.)</t>
 
           <t>Or, if the ICE ufrag and password values have changed, and
-          it is not bundled into another m= section, trigger the ICE agent
+          trigger the ICE agent
           to start an ICE restart, and begin gathering new candidates
           for the m= section as described in
           <xref target="RFC5245" />, Section 9.1.1.1. If this
@@ -3618,8 +3621,7 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
 
             <t>For each specified RTP header extension, establish a
             mapping between the extension ID and URI, as described in
-            section 6 of
-            <xref target="RFC5285" />.</t>
+            <xref target="RFC5285" /> Section 6.</t>
 
             <t>If the MID header extension is supported, prepare to
             demux RTP streams intended for this m= section based on the


### PR DESCRIPTION
The local description can never be wrong, because it is
constructed by the browser.

I also explicitly added text to make clear that the mux state
for any m= line cannot change.