### PR TITLE
Fixing some text that deals with currentDirection.

### DIFF
--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -1146,9 +1146,8 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
           which sender should have its track removed. The sender's
           track is cleared, and the sender stops sending. Future calls
           to createOffer will mark the m= section associated with the
-          sender as recvonly (if transceiver.currentDirection is
-          sendrecv) or as inactive (if transceiver.currentDirection is
-          sendonly).</t>
+          sender as recvonly (if transceiver.direction is sendrecv) or
+          as inactive (if transceiver.direction is sendonly).</t>
         </section>
         <section title="addTransceiver" anchor="sec.addTransceiver">
 
@@ -1707,11 +1706,12 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
           negotiated direction for the transceiver's associated m=
           section. More specifically, it indicates the
           <xref target="RFC3264"></xref> directional attribute of the
-          associated m= section in the last applied answer, with "send"
-          and "recv" directions reversed if it was a remote answer. For
-          example, if the directional attribute for the associated m=
-          section in a remote answer is "recvonly", currentDirection is
-          set to "sendonly".</t>
+          associated m= section in the last applied answer (including
+          provisional answers), with "send" and "recv" directions
+          reversed if it was a remote answer. For example, if the
+          directional attribute for the associated m= section in a
+          remote answer is "recvonly", currentDirection is set to
+          "sendonly".</t>
 
           <t>If an answer that references this transceiver has not yet
           been applied, or if the transceiver is stopped,


### PR DESCRIPTION
Fixes #757.

`currentDirection` is meant to represent "direction in effect", whereas
`direction` represents "direction the application *wants* to negotiate".
So, the direction that `removeTrack` both inspects and modifies should
be `direction`; its purpose is to change the application's desired
direction for a transceiver, regardless of the current state of
negotiation.

Also clarifying that `currentDirection` also reflects the direction
negotiated in a provisional answer, which was the intent (I believe)
but wasn't explicitly stated. This is consistent with it being the
direction "in effect", since applying a provisional answer allows the
endpoint to start sending/receiving media.