### PR TITLE
Incorporate Robert's feedback on modifying SDP

### DIFF
--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -3101,19 +3101,13 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
         createOffer/createAnswer options or RtpTransceiver APIs MUST be
         used.</t>
 
-        <t>Note that the application MAY modify the SDP to reduce the
-        capabilities in the offer it sends to the far side
-        (post-setLocalDescription) or the offer that it installs from
-        the far side (pre-setRemoteDescription), as long as it remains
-        a valid SDP offer and specifies a subset of what was in the
-        original offer. This is safe because the answer is not
-        permitted to expand capabilities, and therefore will just
-        respond to what is present in the offer.</t>
-
-        <t>The application SHOULD NOT modify the SDP in the answer it
-        transmits, as the answer contains the negotiated capabilities,
-        and this can cause the two sides to have different ideas about
-        what exactly was negotiated.</t>
+        <t>After calling setLocalDescription with an offer or answer,
+        the application MAY modify the SDP to reduce its capabilities before
+        sending it to the far side, as long as it follows the rules above
+        that define a valid JSEP offer or answer. Likewise, an application
+        that has received an offer or answer from a peer MAY modify the
+        received SDP, subject to the same constraints, before calling
+        setRemoteDescription.</t>
 
         <t>As always, the application is solely responsible for what it
         sends to the other party, and all incoming SDP will be


### PR DESCRIPTION
Fixes #771.
But also clarify that this can be used to modify an offer OR answer, as
long as it remains a legal JSEP o/a.