### PR TITLE
Add bullet about rejecting all m= sections in a BUNDLE group.

### DIFF
--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -2735,6 +2735,13 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             <t>The bundle policy is "balanced", and this is not the
             first m= section for this media type or in the same bundle
             group as the first m= section for this media type.</t>
+
+            <t>This m= section is in a bundle group, and the group's
+            offerer tagged m= section is being rejected due to one of
+            the above reasons. This requires all m= sections in the
+            bundle group to be rejected, as specified in
+            <xref target="I-D.ietf-mmusic-sdp-bundle-negotiation" />,
+            Section 7.3.3.</t>
           </list></t>
 
           <t>Otherwise, each m= section in the answer should then be


### PR DESCRIPTION
If an answerer rejects the "offerer tagged" m= section (the one
listed first in "a=group:BUNDLE"), the BUNDLE spec requires rejecting
*all* m= sections in the BUNDLE group.

This means that stopping one transceiver between setting an offer and
creating an answer may potentially cause multiple m= sections to be
rejected.

See: https://github.com/w3c/webrtc-pc/issues/1858