### PR TITLE
Stop using the "appdata" field in "a=msid".

### DIFF
--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -2093,19 +2093,8 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
                 <t>For each MediaStream that was associated with the
                 transceiver when it was created via addTrack or
                 addTransceiver, an "a=msid" line, as specified in
-                <xref target="I-D.ietf-mmusic-msid"></xref>, Section 2.
-                If a MediaStreamTrack is attached to the transceiver's
-                RtpSender, the "a=msid" lines MUST use that track's ID.
-                If no MediaStreamTrack is attached, a valid ID MUST be
-                generated, in the same way that the implementation
-                generates IDs for local tracks.</t>
-
-                <t>If no MediaStream is associated with the
-                transceiver, a single "a=msid" line with the special
-                value "-" in place of the MediaStream ID, as specified
-                in
-                <xref target="I-D.ietf-mmusic-msid"></xref>, Section 3.
-                The track ID MUST be selected as described above.</t>
+                <xref target="I-D.ietf-mmusic-msid"></xref>, Section 2,
+                but omitting the "appdata" field.</t>
               </list></t>
 
               <t>If the RtpTransceiver has a sendrecv or sendonly
@@ -2627,10 +2616,10 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
           a=group:LS a1 v1
           m=audio 10000 UDP/TLS/RTP/SAVPF 0
           a=mid:a1
-          a=msid:ms1 mst1a
+          a=msid:ms1
           m=video 10001 UDP/TLS/RTP/SAVPF 96
           a=mid:v1
-          a=msid:ms1 mst1v
+          a=msid:ms1
                 ]]>
 </artwork>
             </figure>
@@ -2648,10 +2637,10 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
           a=group:LS a1 v1
           m=audio 20000 UDP/TLS/RTP/SAVPF 0
           a=mid:a1
-          a=msid:ms2 mst2a
+          a=msid:ms2
           m=video 20001 UDP/TLS/RTP/SAVPF 96
           a=mid:v1
-          a=msid:ms2 mst2v
+          a=msid:ms2
                 ]]>
 </artwork>
             </figure>
@@ -2668,10 +2657,10 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
                 <![CDATA[
           m=audio 20000 UDP/TLS/RTP/SAVPF 0
           a=mid:a1
-          a=msid:ms2a mst2a
+          a=msid:ms2a
           m=video 20001 UDP/TLS/RTP/SAVPF 96
           a=mid:v1
-          a=msid:ms2b mst2v
+          a=msid:ms2b
                 ]]>
 </artwork>
             </figure>
@@ -2859,18 +2848,8 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
               <t>For each MediaStream that was associated with the
               transceiver when it was created via addTrack or
               addTransceiver, an "a=msid" line, as specified in
-              <xref target="I-D.ietf-mmusic-msid"></xref>, Section 2.
-              If a MediaStreamTrack is attached to the transceiver's
-              RtpSender, the "a=msid" lines MUST use that track's ID.
-              If no MediaStreamTrack is attached, a valid ID MUST be
-              generated, in the same way that the implementation
-              generates IDs for local tracks.</t>
-
-              <t>If no MediaStream is associated with the transceiver,
-              a single "a=msid" line with the special value "-" in
-              place of the MediaStream ID, as specified in
-              <xref target="I-D.ietf-mmusic-msid"></xref>, Section 3.
-              The track ID MUST be selected as described above.</t>
+              <xref target="I-D.ietf-mmusic-msid"></xref>, Section 2,
+              but omitting the "appdata" field.</t>
             </list></t>
           </list></t>
 
@@ -3508,7 +3487,7 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host
             <t>If present, "a=msid" attributes MUST be parsed as
             specified in
             <xref target="I-D.ietf-mmusic-msid" />, Section 3.2, and
-            their values stored.</t>
+            their values stored, ignoring any "appdata" field.</t>
 
             <t>Any "a=imageattr" attributes MUST be parsed as specified
             in
@@ -4227,7 +4206,6 @@ a=maxptime:120
 a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid
 a=extmap:2 urn:ietf:params:rtp-hdrext:ssrc-audio-level
 a=msid:47017fee-b6c1-4162-929c-a25110252400
-       f83006c5-a0ff-4e0a-9ed9-d3e6747be7d9
 a=ice-ufrag:ETEn
 a=ice-pwd:OtSK0WpNtpUjkY4+86js7ZQl
 a=fingerprint:sha-256
@@ -4259,7 +4237,6 @@ a=rtcp-fb:100 ccm fir
 a=rtcp-fb:100 nack
 a=rtcp-fb:100 nack pli
 a=msid:47017fee-b6c1-4162-929c-a25110252400
-       f30bdb4a-5db8-49b5-bcdc-e0c9a23172e0
 a=ice-ufrag:BGKk
 a=ice-pwd:mqyWsAjvtKwTGnvhPztQ9mIf
 a=fingerprint:sha-256
@@ -4307,7 +4284,6 @@ a=maxptime:120
 a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid
 a=extmap:2 urn:ietf:params:rtp-hdrext:ssrc-audio-level
 a=msid:61317484-2ed4-49d7-9eb7-1414322a7aae
-       5a7b57b8-f043-4bd1-a45d-09d4dfa31226
 a=ice-ufrag:6sFv
 a=ice-pwd:cOTZKZNVlO9RSGsEGM63JXT2
 a=fingerprint:sha-256
@@ -4337,7 +4313,6 @@ a=rtcp-fb:100 ccm fir
 a=rtcp-fb:100 nack
 a=rtcp-fb:100 nack pli
 a=msid:61317484-2ed4-49d7-9eb7-1414322a7aae
-       4ea4d4a1-2fda-4511-a9cc-1b32c2e59552
 ]]>
 </artwork>
           </figure>
@@ -4486,7 +4461,6 @@ a=maxptime:120
 a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid
 a=extmap:2 urn:ietf:params:rtp-hdrext:ssrc-audio-level
 a=msid:57017fee-b6c1-4162-929c-a25110252400
-       e83006c5-a0ff-4e0a-9ed9-d3e6747be7d9
 a=ice-ufrag:ATEn
 a=ice-pwd:AtSK0WpNtpUjkY4+86js7ZQl
 a=fingerprint:sha-256
@@ -4584,7 +4558,6 @@ a=maxptime:120
 a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid
 a=extmap:2 urn:ietf:params:rtp-hdrext:ssrc-audio-level
 a=msid:71317484-2ed4-49d7-9eb7-1414322a7aae
-       6a7b57b8-f043-4bd1-a45d-09d4dfa31226
 a=ice-ufrag:7sFv
 a=ice-pwd:dOTZKZNVlO9RSGsEGM63JXT2
 a=fingerprint:sha-256
@@ -4687,7 +4660,6 @@ a=maxptime:120
 a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid
 a=extmap:2 urn:ietf:params:rtp-hdrext:ssrc-audio-level
 a=msid:71317484-2ed4-49d7-9eb7-1414322a7aae
-       6a7b57b8-f043-4bd1-a45d-09d4dfa31226
 a=ice-ufrag:7sFv
 a=ice-pwd:dOTZKZNVlO9RSGsEGM63JXT2
 a=fingerprint:sha-256
@@ -4729,7 +4701,6 @@ a=rtcp-fb:100 ccm fir
 a=rtcp-fb:100 nack
 a=rtcp-fb:100 nack pli
 a=msid:71317484-2ed4-49d7-9eb7-1414322a7aae
-       5ea4d4a1-2fda-4511-a9cc-1b32c2e59552
 a=rid:1 send
 a=rid:2 send
 a=rid:3 send
@@ -4753,7 +4724,6 @@ a=rtcp-fb:100 ccm fir
 a=rtcp-fb:100 nack
 a=rtcp-fb:100 nack pli
 a=msid:81317484-2ed4-49d7-9eb7-1414322a7aae
-       6ea4d4a1-2fda-4511-a9cc-1b32c2e59552
 ]]>
 </artwork>
           </figure>
@@ -4792,7 +4762,6 @@ a=maxptime:120
 a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid
 a=extmap:2 urn:ietf:params:rtp-hdrext:ssrc-audio-level
 a=msid:57017fee-b6c1-4162-929c-a25110252400
-       e83006c5-a0ff-4e0a-9ed9-d3e6747be7d9
 a=ice-ufrag:ATEn
 a=ice-pwd:AtSK0WpNtpUjkY4+86js7ZQl
 a=fingerprint:sha-256
@@ -4990,7 +4959,6 @@ a=maxptime:120
 a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid
 a=extmap:2 urn:ietf:params:rtp-hdrext:ssrc-audio-level
 a=msid:bbce3ba6-abfc-ac63-d00a-e15b286f8fce
-       e80098db-7159-3c06-229a-00df2a9b3dbc
 a=ice-ufrag:4ZcD
 a=ice-pwd:ZaaG6OG7tCn4J/lehAGz+HHD
 a=fingerprint:sha-256
@@ -5019,7 +4987,6 @@ a=rtcp-fb:100 ccm fir
 a=rtcp-fb:100 nack
 a=rtcp-fb:100 nack pli
 a=msid:bbce3ba6-abfc-ac63-d00a-e15b286f8fce
-       ac701365-eb06-42df-cc93-7f22bc308789
 a=bundle-only
 ]]>
 </artwork>
@@ -5071,7 +5038,6 @@ a=maxptime:120
 a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid
 a=extmap:2 urn:ietf:params:rtp-hdrext:ssrc-audio-level
 a=msid:751f239e-4ae0-c549-aa3d-890de772998b
-       04b5a445-82cc-c9e8-9ffe-c24d0ef4b0ff
 a=ice-ufrag:TpaA
 a=ice-pwd:t2Ouhc67y8JcCaYZxUUTgKw/
 a=fingerprint:sha-256
@@ -5100,7 +5066,6 @@ a=rtcp-fb:100 ccm fir
 a=rtcp-fb:100 nack
 a=rtcp-fb:100 nack pli
 a=msid:751f239e-4ae0-c549-aa3d-890de772998b
-       39292672-c102-d075-f580-5826f31ca958
 ]]>
 </artwork>
           </figure>
@@ -5151,7 +5116,6 @@ a=maxptime:120
 a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid
 a=extmap:2 urn:ietf:params:rtp-hdrext:ssrc-audio-level
 a=msid:751f239e-4ae0-c549-aa3d-890de772998b
-       04b5a445-82cc-c9e8-9ffe-c24d0ef4b0ff
 a=ice-ufrag:TpaA
 a=ice-pwd:t2Ouhc67y8JcCaYZxUUTgKw/
 a=fingerprint:sha-256
@@ -5183,7 +5147,6 @@ a=rtcp-fb:100 ccm fir
 a=rtcp-fb:100 nack
 a=rtcp-fb:100 nack pli
 a=msid:751f239e-4ae0-c549-aa3d-890de772998b
-       39292672-c102-d075-f580-5826f31ca958
 ]]>
 </artwork>
           </figure>
@@ -5218,7 +5181,6 @@ a=maxptime:120
 a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid
 a=extmap:2 urn:ietf:params:rtp-hdrext:ssrc-audio-level
 a=msid:bbce3ba6-abfc-ac63-d00a-e15b286f8fce
-       e80098db-7159-3c06-229a-00df2a9b3dbc
 a=ice-ufrag:4ZcD
 a=ice-pwd:ZaaG6OG7tCn4J/lehAGz+HHD
 a=fingerprint:sha-256
@@ -5250,7 +5212,6 @@ a=rtcp-fb:100 ccm fir
 a=rtcp-fb:100 nack
 a=rtcp-fb:100 nack pli
 a=msid:bbce3ba6-abfc-ac63-d00a-e15b286f8fce
-       ac701365-eb06-42df-cc93-7f22bc308789
 ]]>
 </artwork>
           </figure>


### PR DESCRIPTION
Fixes #842.

And also https://github.com/w3c/webrtc-pc/issues/1718.

Since introducing transceivers, replaceTrack, early media, etc., the
definition of a MediaStreamTrack has changed and track ID signaling has
become somewhat pointless. In many cases, "sender.track.id" on one side
will not match "receiver.track.id" on the other side; endpoints must use
MIDs or m= section indices or some other means to identify which track
is which.

Thus this PR just removes track ID signaling altogether and the
lingering problems it causes.