### PR TITLE
Rfced 53

### DIFF
--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -4968,16 +4968,6 @@ BobJS->BobUA:       setRemoteDescription with |answer-B2|
 BobUA->AliceUA:     audio+video+data sent from Bob to Alice
 AliceUA->BobUA:     audio+video+data sent from Alice to Bob ]]></sourcecode>
 
-<!-- [rfced] Section 7.2:  We changed "ontrack with" to "ontrack event
-with" per the other three "ontrack event with" items.  Please let us
-know if this is incorrect.
-
-Original:
- BobUA->BobJS:       ontrack with audio track from Alice
-
-Currently:
- BobUA->BobJS:       ontrack event with audio track from Alice -->
-
 	   <t>The SDP for |offer-B1| looks like:</t>
 	   <sourcecode name="offer-B1" type="sdp"><![CDATA[
 v=0

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -4740,7 +4740,7 @@ a=rtpmap:101 H264/90000
 a=fmtp:101 packetization-mode=1;profile-level-id=42e01f
 a=rtpmap:102 rtx/90000
 a=fmtp:102 apt=100
-=rtpmap:103 rtx/90000
+a=rtpmap:103 rtx/90000
 a=fmtp:103 apt=101
 a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid
 a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id
@@ -4761,14 +4761,6 @@ a=rtcp-rsize
 a=candidate:1 1 udp 2113929471 203.0.113.100 10102 typ host
 a=candidate:1 2 udp 2113929470 203.0.113.100 10103 typ host
 a=end-of-candidates ]]></sourcecode>
-
-<!-- [rfced] Sections 7.1, 7.2, and 7.3:  Please confirm that the
-"=" signs in these ten "=rtpmap:103" entries do not need to be
-preceded by an "a" line identifier.  We ask because these are the
-only "=rtpmap:" SDP lines that begin with "=" instead of "a=".
-
-Example from original:
- =rtpmap:103 rtx/90000 -->
 
 	   <t>The SDP for |answer-A1| looks like:</t>
 	   <sourcecode name="answer-A1" type="sdp"><![CDATA[
@@ -4816,7 +4808,7 @@ a=rtpmap:101 H264/90000
 a=fmtp:101 packetization-mode=1;profile-level-id=42e01f
 a=rtpmap:102 rtx/90000
 a=fmtp:102 apt=100
-=rtpmap:103 rtx/90000
+a=rtpmap:103 rtx/90000
 a=fmtp:103 apt=101
 a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid
 a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id
@@ -5121,7 +5113,7 @@ a=rtpmap:101 H264/90000
 a=fmtp:101 packetization-mode=1;profile-level-id=42e01f
 a=rtpmap:102 rtx/90000
 a=fmtp:102 apt=100
-=rtpmap:103 rtx/90000
+a=rtpmap:103 rtx/90000
 a=fmtp:103 apt=101
 a=rtpmap:104 flexfec/90000
 a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid
@@ -5144,7 +5136,7 @@ a=rtpmap:101 H264/90000
 a=fmtp:101 packetization-mode=1;profile-level-id=42e01f
 a=rtpmap:102 rtx/90000
 a=fmtp:102 apt=100
-=rtpmap:103 rtx/90000
+a=rtpmap:103 rtx/90000
 a=fmtp:103 apt=101
 a=rtpmap:104 flexfec/90000
 a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid
@@ -5214,7 +5206,7 @@ a=rtpmap:101 H264/90000
 a=fmtp:101 packetization-mode=1;profile-level-id=42e01f
 a=rtpmap:102 rtx/90000
 a=fmtp:102 apt=100
-=rtpmap:103 rtx/90000
+a=rtpmap:103 rtx/90000
 a=fmtp:103 apt=101
 a=imageattr:100 recv [x=[48:1920],y=[48:1080],q=1.0]
 a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid
@@ -5232,7 +5224,7 @@ a=rtpmap:101 H264/90000
 a=fmtp:101 packetization-mode=1;profile-level-id=42e01f
 a=rtpmap:102 rtx/90000
 a=fmtp:102 apt=100
-=rtpmap:103 rtx/90000
+a=rtpmap:103 rtx/90000
 a=fmtp:103 apt=101
 a=imageattr:100 recv [x=[48:1920],y=[48:1080],q=1.0]
 a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid
@@ -5386,7 +5378,7 @@ a=rtpmap:101 H264/90000
 a=fmtp:101 packetization-mode=1;profile-level-id=42e01f
 a=rtpmap:102 rtx/90000
 a=fmtp:102 apt=100
-=rtpmap:103 rtx/90000
+a=rtpmap:103 rtx/90000
 a=fmtp:103 apt=101
 a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid
 a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id
@@ -5447,7 +5439,7 @@ a=rtpmap:101 H264/90000
 a=fmtp:101 packetization-mode=1;profile-level-id=42e01f
 a=rtpmap:102 rtx/90000
 a=fmtp:102 apt=100
-=rtpmap:103 rtx/90000
+a=rtpmap:103 rtx/90000
 a=fmtp:103 apt=101
 a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid
 a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id
@@ -5510,7 +5502,7 @@ a=rtpmap:101 H264/90000
 a=fmtp:101 packetization-mode=1;profile-level-id=42e01f
 a=rtpmap:102 rtx/90000
 a=fmtp:102 apt=100
-=rtpmap:103 rtx/90000
+a=rtpmap:103 rtx/90000
 a=fmtp:103 apt=101
 a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid
 a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id
@@ -5566,7 +5558,7 @@ a=rtpmap:101 H264/90000
 a=fmtp:101 packetization-mode=1;profile-level-id=42e01f
 a=rtpmap:102 rtx/90000
 a=fmtp:102 apt=100
-=rtpmap:103 rtx/90000
+a=rtpmap:103 rtx/90000
 a=fmtp:103 apt=101
 a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid
 a=extmap:3 urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -6104,14 +6104,41 @@ Suggested:
             <title>3rd Generation Partnership Project; Technical
           Specification Group Services and System Aspects; IP
           Multimedia Subsystem (IMS); Multimedia Telephony; Media
-          handling and interaction (Release 16)</title>
-          <seriesInfo name="3GPP TS" value="26.114 V16.3.0"/>
+          handling and interaction (Release 12)</title>
+          <seriesInfo name="3GPP TS" value="26.114 V12.8.0"/>
             <author>
               <organization>3GPP</organization>
             </author>
-            <date year="2019" month="September"/>
+            <date year="2014" month="December"/>
           </front>
         </reference>
+
+<!-- [rfced] Informative References:  We see on
+<https://www.3gpp.org/DynaReport/26114.htm> that a newer version
+dated September 2019 is available.  The new version also discusses
+CVO (as mentioned in Section 3.6.2 of this document).  May we update
+this listing as suggested below?
+
+Original:
+ This is required regardless of whether the receiver
+ supports performing receive-side rotation (e.g., through CVO
+ [TS26.114]), as it significantly simplifies the matching logic.
+...
+ [TS26.114]
+            3GPP TS 26.114 V12.8.0, "3rd Generation Partnership
+            Project; Technical Specification Group Services and System
+            Aspects; IP Multimedia Subsystem (IMS); Multimedia
+            Telephony; Media handling and interaction (Release 12)",
+            December 2014, <http://www.3gpp.org/DynaReport/26114.htm>.
+
+Suggested:
+ [TS26.114]
+            3GPP, "3rd Generation Partnership Project; Technical
+            Specification Group Services and System Aspects; IP
+            Multimedia Subsystem (IMS); Multimedia Telephony; Media
+            handling and interaction (Release 16)", 3GPP TS 26.114
+            V16.3.0, September 2019,
+            <http://www.3gpp.org/DynaReport/26114.htm>. -->
 
       </references>
     </references>

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -6104,41 +6104,14 @@ Suggested:
             <title>3rd Generation Partnership Project; Technical
           Specification Group Services and System Aspects; IP
           Multimedia Subsystem (IMS); Multimedia Telephony; Media
-          handling and interaction (Release 12)</title>
-          <seriesInfo name="3GPP TS" value="26.114 V12.8.0"/>
+          handling and interaction (Release 16)</title>
+          <seriesInfo name="3GPP TS" value="26.114 V16.3.0"/>
             <author>
               <organization>3GPP</organization>
             </author>
-            <date year="2014" month="December"/>
+            <date year="2019" month="September"/>
           </front>
         </reference>
-
-<!-- [rfced] Informative References:  We see on
-<https://www.3gpp.org/DynaReport/26114.htm> that a newer version
-dated September 2019 is available.  The new version also discusses
-CVO (as mentioned in Section 3.6.2 of this document).  May we update
-this listing as suggested below?
-
-Original:
- This is required regardless of whether the receiver
- supports performing receive-side rotation (e.g., through CVO
- [TS26.114]), as it significantly simplifies the matching logic.
-...
- [TS26.114]
-            3GPP TS 26.114 V12.8.0, "3rd Generation Partnership
-            Project; Technical Specification Group Services and System
-            Aspects; IP Multimedia Subsystem (IMS); Multimedia
-            Telephony; Media handling and interaction (Release 12)",
-            December 2014, <http://www.3gpp.org/DynaReport/26114.htm>.
-
-Suggested:
- [TS26.114]
-            3GPP, "3rd Generation Partnership Project; Technical
-            Specification Group Services and System Aspects; IP
-            Multimedia Subsystem (IMS); Multimedia Telephony; Media
-            handling and interaction (Release 16)", 3GPP TS 26.114
-            V16.3.0, September 2019,
-            <http://www.3gpp.org/DynaReport/26114.htm>. -->
 
       </references>
     </references>

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -4137,40 +4137,6 @@ respectively.  Please review.
 	     sectionFormat="bare"/> and <xref target="RFC4588" section="8.7"
 	     sectionFormat="bare"/> of <xref target="RFC4588"/>.
 
-<!-- [rfced] Sections 5.9 and 5.11:  We had to change "[RFC4588],
-Sections 8.6 and 8.7" to "Sections 8.6 and 8.7 of [RFC4588]"
-(in Section 5.9) and "[RFC3264], Sections 6.1 and 7" to "Sections 6.1
-and 7 of [RFC3264]" (in Section 5.11) in order to get the hyperlinks
-to work properly in the .html/.pdf files.  Please let us know any concerns.
-
-Original:
- *  For each specified "rtx" media format, establish a mapping
-    between the RTX payload type and its associated primary payload
-    type, as described in [RFC4588], Sections 8.6 and 8.7.
-...
- *  If the directional attribute in the answer indicates that the
-    JSEP implementation should be sending media ("sendonly" for
-    local answers, "recvonly" for remote answers, or "sendrecv" for
-    either type of answer), choose the media format to send as the
-    most preferred media format from the remote description that is
-    also locally supported, as discussed in [RFC3264], Sections 6.1
-    and 7, and start transmitting RTP media using that format once
-    the underlying transport layers have been established.
-
-Currently:
- -  For each specified "rtx" media format, establish a mapping
-    between the RTX payload type and its associated primary payload
-    type, as described in Sections 8.6 and 8.7 of [RFC4588].
-...
- -  If the directional attribute in the answer indicates that the
-    JSEP implementation should be sending media ("sendonly" for
-    local answers, "recvonly" for remote answers, or "sendrecv" for
-    either type of answer), choose the media format to send as the
-    most preferred media format from the remote description that is
-    also locally supported, as discussed in Sections 6.1 and 7 of
-    [RFC3264], and start transmitting RTP media using that format
-    once the underlying transport layers have been established. -->
-
  </li>
 	       <li>If the directional attribute is of type "sendrecv" or
 	     "recvonly", enable receipt and decoding of media.</li>


### PR DESCRIPTION
fixed the a= line for rtpmap:103 rtx/90000 in the examples. Fixes #923, Issue 53. Fixes #915, Issue 45 (change already in rfced branch).