### PR TITLE
Rfced 24 33 34 40 uncontroversial

### DIFF
--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -1570,22 +1570,9 @@ Possibly:
           <t>The setConfiguration method allows the global
           configuration of the PeerConnection, which was initially set
           by constructor parameters, to be changed during the session.
-          The effects of this method call depend on when it is invoked,
+          The effects of calling this method depend on when it is invoked,
           and they will differ, depending on which specific parameters are
-          changed:
-
-<!-- [rfced] Section 4.1.16:  Should "The effects of this method call"
-be "The effects of calling this method," and should "This call" be
-"Calling this method"?
-
-Original:
- The effects of this method call
- depend on when it is invoked, and differ depending on which specific
- parameters are changed:
-...
- This call may result in a change to the state of the ICE Agent. -->
-
-</t>
+          changed: </t>
           <ul spacing="normal">
             <li>Any changes to the STUN/TURN servers to use affect the
               next gathering phase. If an ICE gathering phase has
@@ -1617,7 +1604,7 @@ Original:
             <li>The bundle and RTCP-multiplexing policies <bcp14>MUST NOT</bcp14> be
               changed after the construction of the PeerConnection.</li>
           </ul>
-          <t>This call may result in a change to the state of the ICE
+          <t>Calling this method may result in a change to the state of the ICE
           agent.</t>
         </section>
         <section anchor="sec.addicecandidate" numbered="true" toc="default">

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -4968,16 +4968,6 @@ BobJS->BobUA:       setRemoteDescription with |answer-B2|
 BobUA->AliceUA:     audio+video+data sent from Bob to Alice
 AliceUA->BobUA:     audio+video+data sent from Alice to Bob ]]></sourcecode>
 
-<!-- [rfced] Section 7.2:  We changed "ontrack with" to "ontrack event
-with" per the other three "ontrack event with" items.  Please let us
-know if this is incorrect.
-
-Original:
- BobUA->BobJS:       ontrack with audio track from Alice
-
-Currently:
- BobUA->BobJS:       ontrack event with audio track from Alice -->
-
 	   <t>The SDP for |offer-B1| looks like:</t>
 	   <sourcecode name="offer-B1" type="sdp"><![CDATA[
 v=0

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -6104,14 +6104,41 @@ Suggested:
             <title>3rd Generation Partnership Project; Technical
           Specification Group Services and System Aspects; IP
           Multimedia Subsystem (IMS); Multimedia Telephony; Media
-          handling and interaction (Release 16)</title>
-          <seriesInfo name="3GPP TS" value="26.114 V16.3.0"/>
+          handling and interaction (Release 12)</title>
+          <seriesInfo name="3GPP TS" value="26.114 V12.8.0"/>
             <author>
               <organization>3GPP</organization>
             </author>
-            <date year="2019" month="September"/>
+            <date year="2014" month="December"/>
           </front>
         </reference>
+
+<!-- [rfced] Informative References:  We see on
+<https://www.3gpp.org/DynaReport/26114.htm> that a newer version
+dated September 2019 is available.  The new version also discusses
+CVO (as mentioned in Section 3.6.2 of this document).  May we update
+this listing as suggested below?
+
+Original:
+ This is required regardless of whether the receiver
+ supports performing receive-side rotation (e.g., through CVO
+ [TS26.114]), as it significantly simplifies the matching logic.
+...
+ [TS26.114]
+            3GPP TS 26.114 V12.8.0, "3rd Generation Partnership
+            Project; Technical Specification Group Services and System
+            Aspects; IP Multimedia Subsystem (IMS); Multimedia
+            Telephony; Media handling and interaction (Release 12)",
+            December 2014, <http://www.3gpp.org/DynaReport/26114.htm>.
+
+Suggested:
+ [TS26.114]
+            3GPP, "3rd Generation Partnership Project; Technical
+            Specification Group Services and System Aspects; IP
+            Multimedia Subsystem (IMS); Multimedia Telephony; Media
+            handling and interaction (Release 16)", 3GPP TS 26.114
+            V16.3.0, September 2019,
+            <http://www.3gpp.org/DynaReport/26114.htm>. -->
 
       </references>
     </references>

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -3109,23 +3109,7 @@ Original:
           "a=bundle-only" line.</t>
           <t>Attributes that are common between all "m=" sections <bcp14>MAY</bcp14> be
           moved to the session level if explicitly defined to be valid at
-          the session level.
-
-<!-- [rfced] Section 5.3.1: Per "the session level" used elsewhere in this
-document and "ice-options are now at session level" in the Change Log, we 
-changed "to session-level" and "at session-level" to "to the session level"
-and "at the session level."  Please let us know any objections.
-
-Original:
- Attributes that are common between all m= sections MAY be moved to
- session-level, if explicitly defined to be valid at session-level.
-
-Currently:
- Attributes that are common between all "m=" sections MAY be moved to
- the session level if explicitly defined to be valid at the session
- level. -->
-
-</t>
+          the session level.</t>
           <t>The attributes prohibited in the creation of offers are
           also prohibited in the creation of answers.</t>
         </section>

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -1377,27 +1377,7 @@ Suggested:
             tracks. Upon acceptance by the user, the application will
             plug in the tracks it has acquired, which, because ICE handshaking
 	    and DTLS handshaking have likely completed by this point, can
-            start transmitting immediately.
-
-<!-- [rfced] Section 4.1.8.1:  As it appears that "ICE and DTLS
-handshaking have" means "ICE handshaking and DTLS handshaking have,"
-we updated this sentence accordingly.  Please let us know if this is
-incorrect (i.e., if the text refers to one handshaking process, in
-which case "have" should be "has").
-
-Original:
- Upon acceptance by the user, the
- application will plug in the tracks it has acquired, which, because
- ICE and DTLS handshaking have likely completed by this point, can
- start transmitting immediately.
-
-Currently:
- Upon acceptance by the user, the
- application will plug in the tracks it has acquired, which, because
- ICE handshaking and DTLS handshaking have likely completed by this
- point, can start transmitting immediately. -->
-
- The application will also
+            start transmitting immediately. The application will also
             send a new offer to the remote side indicating call
             acceptance and moving the audio and video to be two-way
             media. A detailed example flow along these lines is shown

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -6104,41 +6104,14 @@ Suggested:
             <title>3rd Generation Partnership Project; Technical
           Specification Group Services and System Aspects; IP
           Multimedia Subsystem (IMS); Multimedia Telephony; Media
-          handling and interaction (Release 12)</title>
-          <seriesInfo name="3GPP TS" value="26.114 V12.8.0"/>
+          handling and interaction (Release 16)</title>
+          <seriesInfo name="3GPP TS" value="26.114 V16.3.0"/>
             <author>
               <organization>3GPP</organization>
             </author>
-            <date year="2014" month="December"/>
+            <date year="2019" month="September"/>
           </front>
         </reference>
-
-<!-- [rfced] Informative References:  We see on
-<https://www.3gpp.org/DynaReport/26114.htm> that a newer version
-dated September 2019 is available.  The new version also discusses
-CVO (as mentioned in Section 3.6.2 of this document).  May we update
-this listing as suggested below?
-
-Original:
- This is required regardless of whether the receiver
- supports performing receive-side rotation (e.g., through CVO
- [TS26.114]), as it significantly simplifies the matching logic.
-...
- [TS26.114]
-            3GPP TS 26.114 V12.8.0, "3rd Generation Partnership
-            Project; Technical Specification Group Services and System
-            Aspects; IP Multimedia Subsystem (IMS); Multimedia
-            Telephony; Media handling and interaction (Release 12)",
-            December 2014, <http://www.3gpp.org/DynaReport/26114.htm>.
-
-Suggested:
- [TS26.114]
-            3GPP, "3rd Generation Partnership Project; Technical
-            Specification Group Services and System Aspects; IP
-            Multimedia Subsystem (IMS); Multimedia Telephony; Media
-            handling and interaction (Release 16)", 3GPP TS 26.114
-            V16.3.0, September 2019,
-            <http://www.3gpp.org/DynaReport/26114.htm>. -->
 
       </references>
     </references>

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -913,28 +913,9 @@ candidate:1 1 UDP 1694498815 192.0.2.33 10000 typ host ]]></sourcecode>
         when multiple encodings have been configured for an RtpSender,
         the "m=" section for the RtpSender will include an "a=simulcast"
         attribute, as defined in
-        <xref target="RFC8853" sectionFormat="comma" section="6.2"/>,
+        <xref target="RFC8853" sectionFormat="comma" section="5.1"/>,
         with a "send" simulcast stream description that lists each
         desired encoding, and no "recv" simulcast stream description.
-
-<!-- [rfced] Sections 3.7 and 5.2.1:  We do not see "a=simulcast" or
-"send" mentioned anywhere in Section 6.2 of
-RFC 8853 [I-D.ietf-mmusic-sdp-simulcast].  Please confirm that these citations
-are correct and will be clear to readers.
-
-Original:
- Specifically, when multiple
- encodings have been configured for a RtpSender, the m= section for
- the RtpSender will include an "a=simulcast" attribute, as defined in
- [I-D.ietf-mmusic-sdp-simulcast], Section 6.2, with a "send" simulcast
- stream description that lists each desired encoding, and no "recv"
- simulcast stream description.
-...
- o  If the RtpTransceiver has a sendrecv or sendonly direction and
-    more than one "a=rid" line has been generated, an "a=simulcast"
-    line, with direction "send", as defined in
-    [I-D.ietf-mmusic-sdp-simulcast], Section 6.2. -->
-
         The "m=" section will also include an "a=rid" attribute for each
         encoding, as specified in
         <xref target="RFC8851" sectionFormat="comma" section="4"/>; the use of
@@ -2409,7 +2390,7 @@ Original:
               generated, an "a=simulcast" line, with direction "send",
               as defined in
               <xref target="RFC8853" sectionFormat="comma"
-              section="6.2"/>. The list of RIDs <bcp14>MUST</bcp14>
+              section="5.1"/>. The list of RIDs <bcp14>MUST</bcp14>
 	      include all of the RID identifiers
               used in the "a=rid" lines for this "m="
               section.</li>

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -1483,18 +1483,7 @@ Possibly:
           processed.</t>
           <t>This API changes the local media state; among other
           things, it sets up local resources for sending and encoding
-          media.
-
-<!-- [rfced] Section 4.1.10:  Please confirm that "local media state"
-and "local resources" (as opposed to remote) are correct in the
-context of setRemoteDescription.  (We ask because we see identical
-wording in Section 4.1.9 ("setLocalDescription").)
-
-Original:
- This API changes the local media state; among other things, it sets
- up local resources for sending and encoding media. -->
-
-</t>
+          media. </t>
           <t>If setLocalDescription was previously called with an
           offer, and setRemoteDescription is called with an answer
           (provisional or final), and the media directions are

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -1360,37 +1360,11 @@ Suggested:
             callee actually accepts the call, the application can plug
             in the real MediaStreamTrack and create a new "sendrecv"
             offer to update the previous offer/answer pair and start
-            bidirectional media flow. While this could also be done
-            with a "sendonly" pranswer, followed by a "sendrecv"
-            answer, the initial pranswer leaves the offer/answer
-            exchange open, which means that the caller cannot send an
-            updated offer during this time.
-
-<!-- [rfced] Section 4.1.8.1:  We had trouble with this sentence.
-If neither suggestion below is correct, please clarify.
-
-Original:
- While
- this could also be done with a "sendonly" pranswer, followed by a
- "sendrecv" answer, the initial pranswer leaves the offer-answer
- exchange open, which means that the caller cannot send an updated
- offer during this time.
-
-Suggestion #1:
- While
- this could also be done with a "sendonly" pranswer, if followed by a
- "sendrecv" answer the initial pranswer leaves the offer/answer
- exchange open, which means that the caller cannot send an updated
- offer during this time.
-
-Suggestion #2:
- While
- this could also be done with a "sendonly" pranswer followed by a
- "sendrecv" answer, the initial pranswer leaves the offer/answer
- exchange open, which means that the caller cannot send an updated
- offer during this time. -->
-
-</t>
+	    bidirectional media flow.  While this could also be done 
+	    with a "sendonly" pranswer followed by a "sendrecv" 
+	    answer, the initial pranswer leaves the offer/answer 
+	    exchange open, which means that the caller cannot send an 
+	    updated offer during this time.  </t>
             <t>As an example, consider a typical JSEP application that
             wants to set up audio and video as quickly as possible.
             When the callee receives an offer with audio and video

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -2490,24 +2490,7 @@ Original:
             either the supported STUN/TURN servers or the ICE
             candidate policy) or the "IceRestart" option
             (<xref target="sec.icerestart" format="default"/>) was specified.
-
-<!-- [rfced] Section 5.2.2:  As it appears that "either changes to"
-means "changes to either," we updated this sentence accordingly.
-Please let us know if this is incorrect.
-
-Original (the parentheses around "Section 5.2.3.1" have been fixed):
- o  Each "a=ice-ufrag" and "a=ice-pwd" line MUST stay the same, unless
-    the ICE configuration has changed (either changes to the supported
-    STUN/TURN servers, or the ICE candidate policy), or the
-    "IceRestart" option ( Section 5.2.3.1 was specified.
-
-Currently:
- *  Each "a=ice-ufrag" and "a=ice-pwd" line MUST stay the same, unless
-    the ICE configuration has changed (e.g., changes to either the
-    supported STUN/TURN servers or the ICE candidate policy) or the
-    "IceRestart" option (Section 5.2.3.1) was specified. -->
-
- If the "m="
+            If the "m="
             section is bundled into another "m=" section, it still <bcp14>MUST
             NOT</bcp14> contain any ICE credentials.</li>
             <li>If the "m=" section is not bundled into another "m="

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -1666,7 +1666,7 @@ Possibly:
           associated "m=" section on future calls to createOffer and
           createAnswer. The permitted values for direction are
           "recvonly", "sendrecv", "sendonly", and "inactive", mirroring
-          the identically named directional attributes defined in
+          the identically named direction attributes defined in
           <xref target="RFC4566" sectionFormat="comma" section="6"/>.</t>
           <t>When creating offers, the transceiver direction is
           directly reflected in the output, even for re-offers. When
@@ -1693,26 +1693,11 @@ Possibly:
           <t>The currentDirection property indicates the last
           negotiated direction for the transceiver's associated "m="
           section. More specifically, it indicates the
-          directional attribute <xref target="RFC3264" format="default"/> of the
+          direction attribute <xref target="RFC3264" format="default"/> of the
           associated "m=" section in the last applied answer (including
           provisional answers), with "send" and "recv" directions
-          reversed if it was a remote answer.
-
-<!-- [rfced] Section 4.2.5:  We see "direction attribute" but not
-"directional attribute" in RFC 3264.  Will this text be clear to
-readers?  (We ask because we also see "A direction attribute,
-determined by applying the rules regarding the offered direction
-specified in [RFC3264], Section 6.1" in Section 5.3.1 of this
-document.)
-
-Original:
- More specifically, it
- indicates the [RFC3264] directional attribute of the associated m=
- section in the last applied answer (including provisional answers),
- with "send" and "recv" directions reversed if it was a remote answer. -->
-
- For example, if the
-          directional attribute for the associated "m=" section in a
+          reversed if it was a remote answer.  For example, if the
+          direction attribute for the associated "m=" section in a
           remote answer is "recvonly", currentDirection is set to
           "sendonly".</t>
           <t>If an answer that references this transceiver has not yet
@@ -3979,7 +3964,7 @@ respectively.  Please review.
 	     sectionFormat="bare"/> of <xref target="RFC4588"/>.
 
  </li>
-	       <li>If the directional attribute is of type "sendrecv" or
+	       <li>If the direction attribute is of type "sendrecv" or
 	     "recvonly", enable receipt and decoding of media.</li>
 	     </ul>
 	   </li>
@@ -4292,7 +4277,7 @@ Original:
 	       configure the RTCP transmission for this "m=" section to use
 	       Reduced-Size RTCP, as specified in
 	       <xref target="RFC5506" format="default"/>.</li>
-		 <li>If the directional attribute in the answer indicates
+		 <li>If the direction attribute in the answer indicates
 	       that the JSEP implementation should be sending media
 	       ("sendonly" for local answers, "recvonly" for remote
 	       answers, or "sendrecv" for either type of answer), choose
@@ -4387,7 +4372,7 @@ Original:
 	       feedback, follow the rules and recommendations from
    <xref target="RFC8108" sectionFormat="comma" section="5.4.1"/> to select
 	       which SSRC to use.</li>
-		 <li>If the directional attribute in the answer indicates
+		 <li>If the direction attribute in the answer indicates
 	       that the JSEP implementation should not be sending media
 	       ("recvonly" for local answers, "sendonly" for remote
 	       answers, or "inactive" for either type of answer), stop

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -2053,49 +2053,7 @@ Currently:
             formats <bcp14>MUST</bcp14> include the mandatory audio/video codecs as
             specified in
             <xref target="RFC7874" sectionFormat="comma" section="3"/> and
-            <xref target="RFC7742" sectionFormat="comma" section="5"/>.
-
-<!-- [rfced] Sections 5.2.1, 5.3.1, and 5.11:  As it appears that
-each instance of "Section" in these sentences refers to the section
-number of the cited RFC, as opposed to a section in this document,
-we removed the commas after each first-listed section number, as
-follows (particularly for any readers of the text file).  Please let
-us know if anything is incorrect.
-
-Original:
- o  Unless excluded by the above restrictions, the media formats MUST
-    include the mandatory audio/video codecs as specified in
-    [RFC7874], Section 3, and [RFC7742], Section 5.
-...
- o  For each media format on the m= line, "a=rtpmap" and "a=fmtp"
-    lines, as specified in [RFC4566], Section 6, and [RFC3264],
-    Section 5.1.
-...
- o  For each media format on the m= line, "a=rtpmap" and "a=fmtp"
-    lines, as specified in [RFC4566], Section 6, and [RFC3264],
-    Section 6.1.
-...
- However, new media formats and new RTP header extension values
- are permitted in the answer, as described in [RFC3264],
- Section 7, and [RFC5285], Section 6.
-
-Currently:
- *  Unless excluded by the above restrictions, the media formats MUST
-    include the mandatory audio/video codecs as specified in
-    [RFC7874], Section 3 and [RFC7742], Section 5.
-...
- *  For each media format on the "m=" line, "a=rtpmap" and "a=fmtp"
-    lines, as specified in [RFC4566], Section 6 and [RFC3264],
-    Section 5.1.
-...
- *  For each media format on the "m=" line, "a=rtpmap" and "a=fmtp"
-    lines, as specified in [RFC4566], Section 6 and [RFC3264],
-    Section 6.1.
-...
- However, new media formats and new RTP header extension values
- are permitted in the answer, as described in [RFC3264],
- Section 7 and [RFC5285], Section 6. -->
-</li>
+            <xref target="RFC7742" sectionFormat="comma" section="5"/>.</li>
           </ul>
 
           <t>The "m=" line <bcp14>MUST</bcp14> be followed immediately by a "c=" line,

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -1651,20 +1651,8 @@ Possibly:
         <section anchor="sec.transceiver-stopped" numbered="true" toc="default">
           <name>stopped</name>
           <t>The stopped property indicates whether the transceiver has
-          been stopped, either by a call to stopTransceiver or by
-          applying an answer that rejects the associated "m=" section.
-
-<!-- [rfced] Section 4.2.2:  Will "stopTransceiver" be clear to
-readers?  We could not find this string elsewhere in this document,
-anywhere else in this cluster of documents, in any published RFC, or
-in google searches.
-
-Original:
- The stopped property indicates whether the transceiver has been
- stopped, either by a call to stopTransceiver or by applying an answer
- that rejects the associated m= section. -->
-
- In
+          been stopped, either by a call to stop or by
+          applying an answer that rejects the associated "m=" section. In
           either of these cases, it is set to "true" and otherwise
           will be set to "false".</t>
           <t>A stopped RtpTransceiver does not send any outgoing RTP or

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -2499,43 +2499,7 @@ Original:
             indicated in
             <xref target="RFC5761" sectionFormat="comma" section="5.1.3"/>. If no RTCP
             candidates have yet been gathered, dummy values <bcp14>MUST</bcp14> be
-            used, as described in <xref target="sec.initial-offers"/> above.
-
-<!-- [rfced] Sections 5.2.2, 5.3.1, and 5.3.2:  We changed "the
-initial offer section" and "the initial offers section" to
-"Section 5.2.1," and we changed "the initial answer section" to
-"Section 5.3.1."  Please let us know if these changes are incorrect.
-
-Original:
- If no RTCP candidates have yet been gathered,
- dummy values MUST be used, as described in the initial offer
- section above.
-...
- The process here is identical to that
- indicated in the initial offers section above, except that the
- "a=ice-options" line, with the "trickle" option as specified in
- [I-D.ietf-ice-trickle], Section 3, and the "ice2" option as specified
- in [RFC8445], Section 10, is only included if such an option was
- present in the offer.
-...
- If no RTCP candidates have yet been gathered, dummy values MUST be
- used, as described in the initial answer section above.
-
-Currently:
- If no RTCP candidates have yet been gathered,
- dummy values MUST be used, as described in Section 5.2.1 above.
-...
- The process here is identical to that
- indicated in Section 5.2.1 above, except that the "a=ice-options"
- line, with the "trickle" option as specified in [RFC8840],
- Section 4.1.3 and the "ice2" option as specified in [RFC8445],
- Section 10, is only included if such an option was present in the
- offer.
-...
- If no RTCP candidates have yet been gathered, dummy values MUST be
- used, as described in Section 5.3.1 above. -->
-
-</li>
+            used, as described in <xref target="sec.initial-offers"/> above.</li>
 
             <li>If the "m=" section is not bundled into another "m="
             section, for each candidate that has been gathered during


### PR DESCRIPTION
Several uncontroversial edits were made by the RPC and called out in the XML comments. The authors had no issues with the edits. I removed the comments. Fixes #894 (Issue 24), fixes #903 (issue 33), fixes #904 (issue 34), Fixes #910 (issue 40).

Should I try to made the XML look good or strive for cleaner diffs?  I went with better looking XML here (joined any dangling XML elements (e.g., </t>) with the text in front of it).  