### PR TITLE
IETF 111 comments

### DIFF
--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -2311,7 +2311,7 @@ as specified in <xref target="RFC5245" format="default"/>.</li>
           possible, and media sections will not be marked as bundle-only. This is
           by design, but could cause issues in the rare case of sending a 
           subsequent offer as an initial offer to a non-bundle-aware endpoint
-          via Third Party Call Control (TPCC).</t>
+          via Third Party Call Control (3PCC).</t>
           <t>"a=group:LS" attributes are generated in the same way as
           for initial offers, with the additional stipulation that any
           lip sync groups that were present in the most recent answer


### PR DESCRIPTION
This includes the changes requested at IETF 111 (summarized in https://mailarchive.ietf.org/arch/browse/rtcweb/), which are:
- modified text in S 1.3 (requested by @ekr) to spell out that "must-bundle" is the behavior formerly known as "max-bundle"
- added brief discussion of interaction of BUNDLE and TPCC (requested by @rshpount)