### PR TITLE
Addressing opsdir comments

### DIFF
--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -205,11 +205,11 @@
           When <xref target="RFC8829"/> was published, inconsistencies regarding BUNDLE
           <xref target="RFC8843"/> operation were identified with regard to
           both the specification text as well as implementation behavior. The
-          former concern was addressed via an update to <xref target="RFC8843"/>.
+          former concern was addressed via an update to BUNDLE, see <xref target="RFC9143"/>.
           For the latter concern, it was observed that some implementations 
           implemented the "max-bundle" bundle policy defined in <xref target="RFC8829"/>
           by assuming that bundling had already been negotiated, rather than marking "m=" sections
-          as bundle-only as indicated by the specification.
+          as bundle-only as indicated by the BUNDLE specification.
           In order to prevent unexpected changes to applications relying
           on the pre-standard behavior, the decision
           was made to deprecate "max-bundle" and instead

--- a/draft-ietf-rtcweb-jsep.xml
+++ b/draft-ietf-rtcweb-jsep.xml
@@ -205,7 +205,7 @@
           When <xref target="RFC8829"/> was published, inconsistencies regarding BUNDLE
           <xref target="RFC8843"/> operation were identified with regard to
           both the specification text as well as implementation behavior. The
-          former concern was addressed via an update to BUNDLE, see <xref target="RFC9143"/>.
+          former concern was addressed via an update to BUNDLE (see <xref target="RFC9143"/>).
           For the latter concern, it was observed that some implementations 
           implemented the "max-bundle" bundle policy defined in <xref target="RFC8829"/>
           by assuming that bundling had already been negotiated, rather than marking "m=" sections


### PR DESCRIPTION
Addressing [opsdir comments](https://mailarchive.ietf.org/arch/msg/rtcweb/6a-xbYS2dihJXRRqaGoSNDQVRNQ/).